### PR TITLE
Create ParseTweet API and increase support for updated character count

### DIFF
--- a/conformance/extract.yml
+++ b/conformance/extract.yml
@@ -1,937 +1,1170 @@
 tests:
   mentions:
-    - description: "Extract mention at the begining of a tweet"
-      text: "@username reply"
-      expected: ["username"]
+    - description: 'Extract mention at the begining of a tweet'
+      text: '@username reply'
+      expected: ['username']
 
-    - description: "Extract mention at the end of a tweet"
-      text: "mention @username"
-      expected: ["username"]
+    - description: 'Extract mention at the end of a tweet'
+      text: 'mention @username'
+      expected: ['username']
 
-    - description: "Extract mention in the middle of a tweet"
-      text: "mention @username in the middle"
-      expected: ["username"]
+    - description: 'Extract mention in the middle of a tweet'
+      text: 'mention @username in the middle'
+      expected: ['username']
 
-    - description: "Extract mention of username with underscore"
-      text: "mention @user_name"
-      expected: ["user_name"]
+    - description: 'Extract mention of username with underscore'
+      text: 'mention @user_name'
+      expected: ['user_name']
 
-    - description: "Extract mention of all numeric username"
-      text: "mention @12345"
-      expected: ["12345"]
+    - description: 'Extract mention of all numeric username'
+      text: 'mention @12345'
+      expected: ['12345']
 
-    - description: "Extract mention or multiple usernames"
-      text: "mention @username1 @username2"
-      expected: ["username1", "username2"]
+    - description: 'Extract mention or multiple usernames'
+      text: 'mention @username1 @username2'
+      expected: ['username1', 'username2']
 
-    - description: "Extract mention in the middle of a Japanese tweet"
-      text: "の@usernameに到着を待っている"
-      expected: ["username"]
+    - description: 'Extract mention in the middle of a Japanese tweet'
+      text: 'の@usernameに到着を待っている'
+      expected: ['username']
 
-    - description: "DO NOT extract username ending in @"
-      text: "Current Status: @_@ (cc: @username)"
-      expected: ["username"]
+    - description: 'DO NOT extract username ending in @'
+      text: 'Current Status: @_@ (cc: @username)'
+      expected: ['username']
 
-    - description: "DO NOT extract username followed by accented latin characters"
-      text: "@aliceìnheiro something something"
+    - description: 'DO NOT extract username followed by accented latin characters'
+      text: '@aliceìnheiro something something'
       expected: []
 
-    - description: "Extract lone metion but not @user@user (too close to an email)"
-      text: "@username email me @test@example.com"
-      expected: ["username"]
+    - description: 'Extract lone metion but not @user@user (too close to an email)'
+      text: '@username email me @test@example.com'
+      expected: ['username']
 
     - description: "DO NOT extract 'http' in '@http://' as username"
-      text: "@http://twitter.com"
+      text: '@http://twitter.com'
       expected: []
 
-    - description: "Extract mentions before newline"
+    - description: 'Extract mentions before newline'
       text: "@username\n@mention"
-      expected: ["username", "mention"]
+      expected: ['username', 'mention']
 
     - description: "Extract mentions after 'RT'"
-      text: "RT@username RT:@mention RT @test"
-      expected: ["username", "mention", "test"]
+      text: 'RT@username RT:@mention RT @test'
+      expected: ['username', 'mention', 'test']
 
     - description: "Extract mentions after 'rt'"
-      text: "rt@username rt:@mention rt @test"
-      expected: ["username", "mention", "test"]
+      text: 'rt@username rt:@mention rt @test'
+      expected: ['username', 'mention', 'test']
 
     - description: "Extract mentions after 'Rt'"
-      text: "Rt@username Rt:@mention Rt @test"
-      expected: ["username", "mention", "test"]
+      text: 'Rt@username Rt:@mention Rt @test'
+      expected: ['username', 'mention', 'test']
 
     - description: "Extract mentions after 'rT'"
-      text: "rT@username rT:@mention rT @test"
-      expected: ["username", "mention", "test"]
+      text: 'rT@username rT:@mention rT @test'
+      expected: ['username', 'mention', 'test']
 
-    - description: "DO NOT extract username preceded by !"
-      text: "f!@kn"
+    - description: 'DO NOT extract username preceded by !'
+      text: 'f!@kn'
       expected: []
 
-    - description: "DO NOT extract username preceded by @"
-      text: "f@@kn"
+    - description: 'DO NOT extract username preceded by @'
+      text: 'f@@kn'
       expected: []
 
-    - description: "DO NOT extract username preceded by #"
-      text: "f#@kn"
+    - description: 'DO NOT extract username preceded by #'
+      text: 'f#@kn'
       expected: []
 
-    - description: "DO NOT extract username preceded by $"
-      text: "f$@kn"
+    - description: 'DO NOT extract username preceded by $'
+      text: 'f$@kn'
       expected: []
 
-    - description: "DO NOT extract username preceded by %"
-      text: "f%@kn"
+    - description: 'DO NOT extract username preceded by %'
+      text: 'f%@kn'
       expected: []
 
-    - description: "DO NOT extract username preceded by &"
-      text: "f&@kn"
+    - description: 'DO NOT extract username preceded by &'
+      text: 'f&@kn'
       expected: []
 
-    - description: "DO NOT extract username preceded by *"
-      text: "f*@kn"
+    - description: 'DO NOT extract username preceded by *'
+      text: 'f*@kn'
       expected: []
 
   mentions_with_indices:
-    - description: "Extract a mention at the start"
-      text: "@username yo!"
+    - description: 'Extract a mention at the start'
+      text: '@username yo!'
       expected:
-        - screen_name: "username"
+        - screen_name: 'username'
           indices: [0, 9]
 
-    - description: "Extract a mention that has the same thing mentioned at the start"
-      text: "username @username"
+    - description: 'Extract a mention that has the same thing mentioned at the start'
+      text: 'username @username'
       expected:
-        - screen_name: "username"
+        - screen_name: 'username'
           indices: [9, 18]
 
-    - description: "Extract a mention in the middle of a Japanese tweet"
-      text: "の@usernameに到着を待っている"
+    - description: 'Extract a mention in the middle of a Japanese tweet'
+      text: 'の@usernameに到着を待っている'
       expected:
-        - screen_name: "username"
+        - screen_name: 'username'
           indices: [1, 10]
 
   mentions_or_lists_with_indices:
-    - description: "Extract a mention"
-      text: "@username yo!"
+    - description: 'Extract a mention'
+      text: '@username yo!'
       expected:
-        - screen_name: "username"
-          list_slug: ""
+        - screen_name: 'username'
+          list_slug: ''
           indices: [0, 9]
 
-    - description: "Extract a list"
-      text: "@username/list-name is a great list!"
+    - description: 'Extract a list'
+      text: '@username/list-name is a great list!'
       expected:
-        - screen_name: "username"
-          list_slug: "/list-name"
+        - screen_name: 'username'
+          list_slug: '/list-name'
           indices: [0, 19]
 
-    - description: "Extract a mention and list"
-      text: "Hey @username, check out out @otheruser/list_name-01!"
+    - description: 'Extract a mention and list'
+      text: 'Hey @username, check out out @otheruser/list_name-01!'
       expected:
-        - screen_name: "username"
-          list_slug: ""
+        - screen_name: 'username'
+          list_slug: ''
           indices: [4, 13]
-        - screen_name: "otheruser"
-          list_slug: "/list_name-01"
+        - screen_name: 'otheruser'
+          list_slug: '/list_name-01'
           indices: [29, 52]
 
-    - description: "Extract a list in the middle of a Japanese tweet"
-      text: "の@username/list_name-01に到着を待っている"
+    - description: 'Extract a list in the middle of a Japanese tweet'
+      text: 'の@username/list_name-01に到着を待っている'
       expected:
-        - screen_name: "username"
-          list_slug: "/list_name-01"
+        - screen_name: 'username'
+          list_slug: '/list_name-01'
           indices: [1, 23]
 
-    - description: "DO NOT extract a list with slug that starts with a number"
-      text: "@username/7list-name is a great list!"
+    - description: 'DO NOT extract a list with slug that starts with a number'
+      text: '@username/7list-name is a great list!'
       expected:
-        - screen_name: "username"
-          list_slug: ""
+        - screen_name: 'username'
+          list_slug: ''
           indices: [0, 9]
 
   replies:
-    - description: "Extract reply at the begining of a tweet"
-      text: "@username reply"
-      expected: "username"
+    - description: 'Extract reply at the begining of a tweet'
+      text: '@username reply'
+      expected: 'username'
 
-    - description: "Extract reply preceded by only a space"
-      text: " @username reply"
-      expected: "username"
+    - description: 'Extract reply preceded by only a space'
+      text: ' @username reply'
+      expected: 'username'
 
-    - description: "Extract reply preceded by only a full-width space (U+3000)"
-      text: "　@username reply"
-      expected: "username"
+    - description: 'Extract reply preceded by only a full-width space (U+3000)'
+      text: '　@username reply'
+      expected: 'username'
 
-    - description: "DO NOT Extract reply when preceded by text"
-      text: "a @username mention, not a reply"
+    - description: 'DO NOT Extract reply when preceded by text'
+      text: 'a @username mention, not a reply'
       expected:
 
-    - description: "DO NOT Extract reply when preceded by ."
-      text: ".@username mention, not a reply"
+    - description: 'DO NOT Extract reply when preceded by .'
+      text: '.@username mention, not a reply'
       expected:
 
-    - description: "DO NOT Extract reply when preceded by /"
-      text: "/@username mention, not a reply"
+    - description: 'DO NOT Extract reply when preceded by /'
+      text: '/@username mention, not a reply'
       expected:
 
-    - description: "DO NOT Extract reply when preceded by _"
-      text: "_@username mention, not a reply"
+    - description: 'DO NOT Extract reply when preceded by _'
+      text: '_@username mention, not a reply'
       expected:
 
-    - description: "DO NOT Extract reply when preceded by -"
-      text: "-@username mention, not a reply"
+    - description: 'DO NOT Extract reply when preceded by -'
+      text: '-@username mention, not a reply'
       expected:
 
-    - description: "DO NOT Extract reply when preceded by +"
-      text: "+@username mention, not a reply"
+    - description: 'DO NOT Extract reply when preceded by +'
+      text: '+@username mention, not a reply'
       expected:
 
-    - description: "DO NOT Extract reply when preceded by #"
-      text: "#@username mention, not a reply"
+    - description: 'DO NOT Extract reply when preceded by #'
+      text: '#@username mention, not a reply'
       expected:
 
-    - description: "DO NOT Extract reply when preceded by !"
-      text: "!@username mention, not a reply"
+    - description: 'DO NOT Extract reply when preceded by !'
+      text: '!@username mention, not a reply'
       expected:
 
-    - description: "DO NOT Extract reply when preceded by @"
-      text: "@@username mention, not a reply"
+    - description: 'DO NOT Extract reply when preceded by @'
+      text: '@@username mention, not a reply'
       expected:
 
-    - description: "DO NOT Extract reply when followed by URL"
-      text: "@http://twitter.com"
+    - description: 'DO NOT Extract reply when followed by URL'
+      text: '@http://twitter.com'
       expected:
 
   urls:
-    - description: "Extract a lone URL"
-      text: "http://example.com"
-      expected: ["http://example.com"]
+    - description: 'Extract a lone URL'
+      text: 'http://example.com'
+      expected: ['http://example.com']
 
-    - description: "Extract valid URL: http://google.com"
-      text: "text http://google.com"
-      expected: ["http://google.com"]
+    - description: 'Extract a lone unicode url'
+      text: 'http://ああ.com'
+      expected: ['http://ああ.com']
 
-    - description: "Extract valid URL: http://foobar.com/#"
-      text: "text http://foobar.com/#"
-      expected: ["http://foobar.com/#"]
+    - description: 'Extract a lone unicode url with -'
+      text: 'http://あ-あ.com'
+      expected: ['http://あ-あ.com']
 
-    - description: "Extract valid URL: http://google.com/#foo"
-      text: "text http://google.com/#foo"
-      expected: ["http://google.com/#foo"]
+    - description: 'Extract valid URL: http://google.com'
+      text: 'text http://google.com'
+      expected: ['http://google.com']
 
-    - description: "Extract valid URL: http://google.com/#search?q=iphone%20-filter%3Alinks"
-      text: "text http://google.com/#search?q=iphone%20-filter%3Alinks"
-      expected: ["http://google.com/#search?q=iphone%20-filter%3Alinks"]
+    - description: 'Extract valid URL: http://foobar.com/#'
+      text: 'text http://foobar.com/#'
+      expected: ['http://foobar.com/#']
 
-    - description: "Extract valid URL: http://twitter.com/#search?q=iphone%20-filter%3Alinks"
-      text: "text http://twitter.com/#search?q=iphone%20-filter%3Alinks"
-      expected: ["http://twitter.com/#search?q=iphone%20-filter%3Alinks"]
+    - description: 'Extract valid URL: http://google.com/#foo'
+      text: 'text http://google.com/#foo'
+      expected: ['http://google.com/#foo']
 
-    - description: "Extract valid URL: http://somedomain.com/index.php?path=/abc/def/"
-      text: "text http://somedomain.com/index.php?path=/abc/def/"
-      expected: ["http://somedomain.com/index.php?path=/abc/def/"]
+    - description: 'Extract valid URL: http://google.com/#search?q=iphone%20-filter%3Alinks'
+      text: 'text http://google.com/#search?q=iphone%20-filter%3Alinks'
+      expected: ['http://google.com/#search?q=iphone%20-filter%3Alinks']
 
-    - description: "Extract valid URL: http://www.boingboing.net/2007/02/14/katamari_damacy_phon.html"
-      text: "text http://www.boingboing.net/2007/02/14/katamari_damacy_phon.html"
-      expected: ["http://www.boingboing.net/2007/02/14/katamari_damacy_phon.html"]
+    - description: 'Extract valid URL: http://twitter.com/#search?q=iphone%20-filter%3Alinks'
+      text: 'text http://twitter.com/#search?q=iphone%20-filter%3Alinks'
+      expected: ['http://twitter.com/#search?q=iphone%20-filter%3Alinks']
 
-    - description: "Extract valid URL: http://somehost.com:3000"
-      text: "text http://somehost.com:3000"
-      expected: ["http://somehost.com:3000"]
+    - description: 'Extract valid URL: http://somedomain.com/index.php?path=/abc/def/'
+      text: 'text http://somedomain.com/index.php?path=/abc/def/'
+      expected: ['http://somedomain.com/index.php?path=/abc/def/']
 
-    - description: "Extract valid URL: http://xo.com/~matthew+%ff-x"
-      text: "text http://xo.com/~matthew+%ff-x"
-      expected: ["http://xo.com/~matthew+%ff-x"]
+    - description: 'Extract valid URL: http://www.boingboing.net/2007/02/14/katamari_damacy_phon.html'
+      text: 'text http://www.boingboing.net/2007/02/14/katamari_damacy_phon.html'
+      expected:
+        ['http://www.boingboing.net/2007/02/14/katamari_damacy_phon.html']
 
-    - description: "Extract valid URL: http://xo.com/~matthew+%ff-,.;x"
-      text: "text http://xo.com/~matthew+%ff-,.;x"
-      expected: ["http://xo.com/~matthew+%ff-,.;x"]
+    - description: 'Extract valid URL: http://somehost.com:3000'
+      text: 'text http://somehost.com:3000'
+      expected: ['http://somehost.com:3000']
 
-    - description: "Extract valid URL: http://xo.com/,.;x"
-      text: "text http://xo.com/,.;x"
-      expected: ["http://xo.com/,.;x"]
+    - description: 'Extract valid URL: http://xo.com/~matthew+%ff-x'
+      text: 'text http://xo.com/~matthew+%ff-x'
+      expected: ['http://xo.com/~matthew+%ff-x']
 
-    - description: "Extract valid URL: http://en.wikipedia.org/wiki/Primer_(film)"
-      text: "text http://en.wikipedia.org/wiki/Primer_(film)"
-      expected: ["http://en.wikipedia.org/wiki/Primer_(film)"]
+    - description: 'Extract valid URL: http://xo.com/~matthew+%ff-,.;x'
+      text: 'text http://xo.com/~matthew+%ff-,.;x'
+      expected: ['http://xo.com/~matthew+%ff-,.;x']
 
-    - description: "Extract valid URL: http://www.ams.org/bookstore-getitem/item=mbk-59"
-      text: "text http://www.ams.org/bookstore-getitem/item=mbk-59"
-      expected: ["http://www.ams.org/bookstore-getitem/item=mbk-59"]
+    - description: 'Extract valid URL: http://xo.com/,.;x'
+      text: 'text http://xo.com/,.;x'
+      expected: ['http://xo.com/,.;x']
 
-    - description: "Extract valid URL: http://✪df.ws/ejp"
-      text: "text http://✪df.ws/ejp"
-      expected: ["http://✪df.ws/ejp"]
+    - description: 'Extract valid URL: http://en.wikipedia.org/wiki/Primer_(film)'
+      text: 'text http://en.wikipedia.org/wiki/Primer_(film)'
+      expected: ['http://en.wikipedia.org/wiki/Primer_(film)']
 
-    - description: "Extract valid URL: http://chilp.it/?77e8fd"
-      text: "text http://chilp.it/?77e8fd"
-      expected: ["http://chilp.it/?77e8fd"]
+    - description: 'Extract valid URL: http://www.ams.org/bookstore-getitem/item=mbk-59'
+      text: 'text http://www.ams.org/bookstore-getitem/item=mbk-59'
+      expected: ['http://www.ams.org/bookstore-getitem/item=mbk-59']
 
-    - description: "Extract valid URL: http://x.com/oneletterdomain"
-      text: "text http://x.com/oneletterdomain"
-      expected: ["http://x.com/oneletterdomain"]
+    - description: 'Extract valid URL: http://✪df.ws/ejp'
+      text: 'text http://✪df.ws/ejp'
+      expected: ['http://✪df.ws/ejp']
 
-    - description: "Extract valid URL: http://msdn.microsoft.com/ja-jp/library/system.net.httpwebrequest(v=VS.100).aspx"
-      text: "text http://msdn.microsoft.com/ja-jp/library/system.net.httpwebrequest(v=VS.100).aspx"
-      expected: ["http://msdn.microsoft.com/ja-jp/library/system.net.httpwebrequest(v=VS.100).aspx"]
+    - description: 'Extract valid URL: http://example.com/'
+      text: 'test http://example.comだよね.comtest/hogehoge'
+      expected: ['http://example.com']
 
-    - description: "DO NOT extract invalid URL: http://domain-begin_dash_2314352345_dfasd.foo-cow_4352.com"
-      text: "text http://domain-dash_2314352345_dfasd.foo-cow_4352.com"
+    - description: 'Extract valid URL: http://chilp.it/?77e8fd'
+      text: 'text http://chilp.it/?77e8fd'
+      expected: ['http://chilp.it/?77e8fd']
+
+    - description: 'Extract valid URL: http://x.com/oneletterdomain'
+      text: 'text http://x.com/oneletterdomain'
+      expected: ['http://x.com/oneletterdomain']
+
+    - description: 'Extract valid URL: http://msdn.microsoft.com/ja-jp/library/system.net.httpwebrequest(v=VS.100).aspx'
+      text: 'text http://msdn.microsoft.com/ja-jp/library/system.net.httpwebrequest(v=VS.100).aspx'
+      expected:
+        [
+          'http://msdn.microsoft.com/ja-jp/library/system.net.httpwebrequest(v=VS.100).aspx',
+        ]
+
+    - description: 'Extract valid URL with hyphen as query ending char: https://www.youtube.com/watch?v=LOxOAuDHzaw&list=PLPoq910Q9jXhuH6pit_KwIsck9fEz_9U-'
+      text: 'text https://www.youtube.com/watch?v=LOxOAuDHzaw&list=PLPoq910Q9jXhuH6pit_KwIsck9fEz_9U-'
+      expected:
+        [
+          'https://www.youtube.com/watch?v=LOxOAuDHzaw&list=PLPoq910Q9jXhuH6pit_KwIsck9fEz_9U-',
+        ]
+
+    - description: 'DO NOT extract invalid URL: http://no-tld'
+      text: 'text http://no-tld'
       expected: []
 
-    - description: "DO NOT extract invalid URL: http://-begin_dash_2314352345_dfasd.foo-cow_4352.com"
-      text: "text http://-dash_2314352345_dfasd.foo-cow_4352.com"
+    - description: 'DO NOT extract invalid URL: http://tld-too-short.x'
+      text: 'text http://tld-too-short.x'
       expected: []
 
-    - description: "DO NOT extract invalid URL: http://no-tld"
-      text: "text http://no-tld"
+    - description: 'DO NOT extract invalid URL with invalid preceding character: (http://twitter.com'
+      text: '(http://twitter.com'
+      expected: ['http://twitter.com']
+
+    - description: 'Extract a very long hyphenated sub-domain URL (single letter hyphens)'
+      text: 'text http://word-and-a-number-8-ftw.domain.com/'
+      expected: ['http://word-and-a-number-8-ftw.domain.com/']
+
+    - description: "DO NOT Extract a hyphenated TLD (even though it's usually a typo)"
+      text: 'text http://domain.com-that-you-should-have-put-a-space-after'
       expected: []
 
-    - description: "DO NOT extract invalid URL: http://tld-too-short.x"
-      text: "text http://tld-too-short.x"
+    - description: 'Extract URL ending with # value'
+      text: 'text http://foo.com?#foo text'
+      expected: ['http://foo.com?#foo']
+
+    - description: 'Extract URLs without protocol on (com|org|edu|gov|net) domains'
+      text: 'foo.com foo.net foo.org foo.edu foo.gov'
+      expected: ['foo.com', 'foo.net', 'foo.org', 'foo.edu', 'foo.gov']
+
+    - description: 'Extract URLs without protocol not on (com|org|edu|gov|net) domains'
+      text: 'foo.baz foo.co.jp www.xxxxxxx.baz www.foo.co.uk wwwww.xxxxxxx foo.comm foo.somecom foo.govedu foo.jp'
+      expected: ['foo.co.jp', 'www.foo.co.uk', 'foo.jp']
+
+    - description: 'Extract URLs without protocol on ccTLD with slash'
+      text: 't.co/abcde bit.ly/abcde'
+      expected: ['t.co/abcde', 'bit.ly/abcde']
+
+    - description: 'Extract URLs with protocol on ccTLD domains'
+      text: 'http://foo.jp http://fooooo.jp'
+      expected: ['http://foo.jp', 'http://fooooo.jp']
+
+    - description: 'Extract URLs with a - or + at the end of the path'
+      text: 'Go to http://example.com/a+ or http://example.com/a-'
+      expected: ['http://example.com/a+', 'http://example.com/a-']
+
+    - description: 'Extract URLs with longer paths ending in -'
+      text: 'Go to http://example.com/view/slug-url-?foo=bar'
+      expected: ['http://example.com/view/slug-url-?foo=bar']
+
+    - description: 'Extract URLs with an en dash in the path'
+      text: 'Go to https://en.m.wikipedia.org/wiki/Hatfield–McCoy_feud please'
+      expected: ['https://en.m.wikipedia.org/wiki/Hatfield–McCoy_feud']
+
+    - description: 'Extract URLs beginning with a space'
+      text: '@user Try http:// example.com/path'
+      expected: ['example.com/path']
+
+    - description: 'Extract long URL without protocol surrounded by CJK characters'
+      text: 'これは日本語です。example.com/path/index.html中国語example.com/path한국'
+      expected: ['example.com/path/index.html', 'example.com/path']
+
+    - description: 'Extract short URL without protocol surrounded by CJK characters'
+      text: 'twitter.comこれは日本語です。example.com中国語t.co/abcde한국twitter.com example2.comテストtwitter.com/abcde'
+      expected:
+        [
+          'twitter.com',
+          'example.com',
+          't.co/abcde',
+          'twitter.com',
+          'example2.com',
+          'twitter.com/abcde',
+        ]
+
+    - description: 'Extract URLs with and without protocol surrounded by CJK characters'
+      text: 'http://twitter.com/これは日本語です。example.com中国語http://t.co/abcde한국twitter.comテストexample2.comテストhttp://twitter.com/abcde'
+      expected:
+        [
+          'http://twitter.com/',
+          'example.com',
+          'http://t.co/abcde',
+          'twitter.com',
+          'example2.com',
+          'http://twitter.com/abcde',
+        ]
+
+    - description: 'Extract URLs with protocol and path containing Cyrillic characters'
+      text: 'Go to http://twitter.com/Русские_слова'
+      expected: ['http://twitter.com/Русские_слова']
+
+    - description: 'Extract non-ASCII host name URLs with protocol, but ignore host names bigger than 63 characters. Also handle exceptions for non-ASCII hostnames longer than 256 characters'
+      text: 'http://exampleこれは日本語です.com/path/index.html http://あああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああ.com/path/index.html'
+      expected: ['http://exampleこれは日本語です.com/path/index.html']
+
+    - description: 'Extract short URLs without protocol on ccTLD domains without path'
+      text: 'twitter.jp日本語it.so中国語foo.jp it.so foo.jp'
+      expected: ['twitter.jp', 'it.so', 'foo.jp', 'it.so', 'foo.jp']
+
+    - description: 'DO NOT extract invalid URL'
+      text: 'Hello http://xn--はじめよう.com/index.html'
       expected: []
 
-    - description: "DO NOT extract invalid URL with invalid preceding character: (http://twitter.com"
-      text: "(http://twitter.com"
-      expected: ["http://twitter.com"]
-
-    - description: "Extract a very long hyphenated sub-domain URL (single letter hyphens)"
-      text: "text http://word-and-a-number-8-ftw.domain.com/"
-      expected: ["http://word-and-a-number-8-ftw.domain.com/"]
-
-    - description: "Extract a hyphenated TLD (usually a typo)"
-      text: "text http://domain.com-that-you-should-have-put-a-space-after"
-      expected: ["http://domain.com"]
-
-    - description: "Extract URL ending with # value"
-      text: "text http://foo.com?#foo text"
-      expected: ["http://foo.com?#foo"]
-
-    - description: "Extract URLs without protocol on (com|org|edu|gov|net) domains"
-      text: "foo.com foo.net foo.org foo.edu foo.gov"
-      expected: ["foo.com", "foo.net", "foo.org", "foo.edu", "foo.gov"]
-
-    - description: "Extract URLs without protocol not on (com|org|edu|gov|net) domains"
-      text: "foo.baz foo.co.jp www.xxxxxxx.baz www.foo.co.uk wwwww.xxxxxxx foo.comm foo.somecom foo.govedu foo.jp"
-      expected: ["foo.co.jp", "www.foo.co.uk"]
-
-    - description: "Extract URLs without protocol on ccTLD with slash"
-      text: "t.co/abcde bit.ly/abcde"
-      expected: ["t.co/abcde", "bit.ly/abcde"]
-
-    - description: "Extract URLs with protocol on ccTLD domains"
-      text: "http://foo.jp http://fooooo.jp"
-      expected: ["http://foo.jp", "http://fooooo.jp"]
-
-    - description: "Extract URLs with a - or + at the end of the path"
-      text: "Go to http://example.com/a+ or http://example.com/a-"
-      expected: ["http://example.com/a+", "http://example.com/a-"]
-
-    - description: "Extract URLs with longer paths ending in -"
-      text: "Go to http://example.com/view/slug-url-?foo=bar"
-      expected: ["http://example.com/view/slug-url-?foo=bar"]
-
-    - description: "Extract URLs beginning with a space"
-      text: "@user Try http:// example.com/path"
-      expected: ["example.com/path"]
-
-    - description: "Extract long URL without protocol surrounded by CJK characters"
-      text: "これは日本語です。example.com/path/index.html中国語example.com/path한국"
-      expected: ["example.com/path/index.html", "example.com/path"]
-
-    - description: "Extract short URL without protocol surrounded by CJK characters"
-      text: "twitter.comこれは日本語です。example.com中国語t.co/abcde한국twitter.com example2.comテストtwitter.com/abcde"
-      expected: ["twitter.com", "example.com", "t.co/abcde", "twitter.com", "example2.com", "twitter.com/abcde"]
-
-    - description: "Extract URLs with and without protocol surrounded by CJK characters"
-      text: "http://twitter.com/これは日本語です。example.com中国語http://t.co/abcde한국twitter.comテストexample2.comテストhttp://twitter.com/abcde"
-      expected: ["http://twitter.com/", "example.com", "http://t.co/abcde", "twitter.com", "example2.com", "http://twitter.com/abcde"]
-
-    - description: "DO NOT extract short URLs without protocol on ccTLD domains without path"
-      text: "twitter.jp日本語it.so中国語foo.jp it.so foo.jp"
+    - description: 'DO NOT Extract URL with domain preceeded by underscore: http://domain-begin_dash_2314352345_dfasd.foo-cow_4352.com'
+      text: 'text http://domain-dash_2314352345_dfasd.foo-cow_4352.com'
       expected: []
 
-    - description: "Extract some (tv|co) short URLs without protocol on ccTLD domains without path"
-      text: "MLB.tv vine.co twitch.tv t.co"
-      expected: ["MLB.tv", "vine.co", "twitch.tv", "t.co"]
-
-    - description: "Extract URLs beginning with a non-breaking space (U+00A0)"
-      text: "@user Try http:// example.com/path"
-      expected: ["example.com/path"]
-
-    - description: "Extract URLs with underscores and dashes in the subdomain"
-      text: "test http://sub_domain-dash.twitter.com"
-      expected: ["http://sub_domain-dash.twitter.com"]
-
-    - description: "Extract URL with minimum number of valid characters"
-      text: "test http://a.b.cd"
-      expected: ["http://a.b.cd"]
-
-    - description: "Extract URLs containing underscores and dashes"
-      text: "test http://a_b.c-d.com"
-      expected: ["http://a_b.c-d.com"]
-
-    - description: "Extract URLs containing dashes in the subdomain"
-      text: "test http://a-b.c.com"
-      expected: ["http://a-b.c.com"]
-
-    - description: "Extract URLs with dashes in the domain name"
-      text: "test http://twitter-dash.com"
-      expected: ["http://twitter-dash.com"]
-
-    - description: "Extract URLs with lots of symbols then a period"
-      text: "http://www.bestbuy.com/site/Currie+Technologies+-+Ezip+400+Scooter/9885188.p?id=1218189013070&skuId=9885188"
-      expected: ["http://www.bestbuy.com/site/Currie+Technologies+-+Ezip+400+Scooter/9885188.p?id=1218189013070&skuId=9885188"]
-
-    - description: "DO NOT extract URLs containing leading dashes in the subdomain"
-      text: "test http://-leadingdash.twitter.com"
+    - description: 'DO NOT Extract URLs with a - or + in the middle of an email address'
+      text: 'Email me at name.al-lastname@foo.com or name.al+lastname@foo.com'
       expected: []
 
-    - description: "DO NOT extract URLs containing trailing dashes in the subdomain"
-      text: "test http://trailingdash-.twitter.com"
+    - description: 'Extract URLs with a - in the middle'
+      text: 'Find my page at name.al-lastname.com'
+      expected: ['name.al-lastname.com']
+
+    - description: 'Extract some (tv|co) short URLs without protocol on ccTLD domains without path'
+      text: 'MLB.tv vine.co twitch.tv t.co'
+      expected: ['MLB.tv', 'vine.co', 'twitch.tv', 't.co']
+
+    - description: 'Extract URLs beginning with a non-breaking space (U+00A0)'
+      text: '@user Try http:// example.com/path'
+      expected: ['example.com/path']
+
+    - description: 'Extract URLs with underscores and dashes in the subdomain'
+      text: 'test http://sub_domain-dash.twitter.com'
+      expected: ['http://sub_domain-dash.twitter.com']
+
+    - description: 'Extract URL with minimum number of valid characters'
+      text: 'test http://a.b.cd'
+      expected: ['http://a.b.cd']
+
+    - description: 'Extract URLs containing underscores and dashes'
+      text: 'test http://a_b.c-d.com'
+      expected: ['http://a_b.c-d.com']
+
+    - description: 'Extract URLs containing dashes in the subdomain'
+      text: 'test http://a-b.c.com'
+      expected: ['http://a-b.c.com']
+
+    - description: 'Extract URLs with dashes in the domain name'
+      text: 'test http://twitter-dash.com'
+      expected: ['http://twitter-dash.com']
+
+    - description: 'Extract URLs with lots of symbols then a period'
+      text: 'http://www.bestbuy.com/site/Currie+Technologies+-+Ezip+400+Scooter/9885188.p?id=1218189013070&skuId=9885188'
+      expected:
+        [
+          'http://www.bestbuy.com/site/Currie+Technologies+-+Ezip+400+Scooter/9885188.p?id=1218189013070&skuId=9885188',
+        ]
+
+    - description: 'DO NOT extract URLs containing leading dashes in the subdomain'
+      text: 'test http://-leadingdash.twitter.com'
       expected: []
 
-    - description: "DO NOT extract URLs containing leading underscores in the subdomain"
-      text: "test http://_leadingunderscore.twitter.com"
+    - description: 'DO NOT extract URLs containing leading dashes in the domain with a subdomain'
+      text: 'test http://leadingdash.-twitter.com'
       expected: []
 
-    - description: "DO NOT extract URLs containing trailing underscores in the subdomain"
-      text: "test http://trailingunderscore_.twitter.com"
+    - description: 'DO NOT extract URLs containing trailing dashes in the subdomain'
+      text: 'test http://trailingdash-.twitter.com'
       expected: []
 
-    - description: "DO NOT extract URLs containing leading dashes in the domain name"
-      text: "test http://-twitter.com"
+    - description: 'DO NOT extract URLs containing trailing dashes in the domain with a subdomain'
+      text: 'test http://trailingdash.twitter-.com'
       expected: []
 
-    - description: "DO NOT extract URLs containing trailing dashes in the domain name"
-      text: "test http://twitter-.com"
+    - description: 'DO NOT extract URLs containing leading underscores in the subdomain'
+      text: 'test http://_leadingunderscore.twitter.com'
       expected: []
 
-    - description: "DO NOT extract URLs containing underscores in the domain name"
-      text: "test http://twitter_underscore.com"
+    - description: 'DO NOT extract URLs containing leading underscores in the domain with a subdomain'
+      text: 'test http://leadingunderscore._twitter.com'
       expected: []
 
-    - description: "DO NOT extract URLs containing underscores in the tld"
-      text: "test http://twitter.c_o_m"
+    - description: 'DO NOT extract URLs containing trailing underscores in the subdomain'
+      text: 'test http://trailingunderscore_.twitter.com'
       expected: []
 
-    - description: "Extract valid URL http://www.foo.com/foo/path-with-period./"
-      text: "test http://www.foo.com/foo/path-with-period./"
-      expected: ["http://www.foo.com/foo/path-with-period./"]
+    - description: 'DO NOT extract URLs containing trailing underscores in the domain with a subdomain'
+      text: 'test http://trailingunderscore.twitter_.com'
+      expected: []
 
-    - description: "Extract valid URL http://www.foo.org.za/foo/bar/688.1"
-      text: "test http://www.foo.org.za/foo/bar/688.1"
-      expected: ["http://www.foo.org.za/foo/bar/688.1"]
+    - description: 'DO NOT extract URLs containing leading dashes in the domain name'
+      text: 'test http://-twitter.com'
+      expected: []
 
-    - description: "Extract valid URL http://www.foo.com/bar-path/some.stm?param1=foo;param2=P1|0||P2|0"
-      text: "test http://www.foo.com/bar-path/some.stm?param1=foo;param2=P1|0||P2|0"
-      expected: ["http://www.foo.com/bar-path/some.stm?param1=foo;param2=P1|0||P2|0"]
+    - description: 'DO NOT extract URLs containing trailing dashes in the domain name'
+      text: 'test http://twitter-.com'
+      expected: []
 
-    - description: "Extract valid URL http://foo.com/bar/123/foo_&_bar/"
-      text: "test http://foo.com/bar/123/foo_&_bar/"
-      expected: ["http://foo.com/bar/123/foo_&_bar/"]
+    - description: 'DO NOT extract URLs containing underscores in the domain name'
+      text: 'test http://twitter_underscore.com'
+      expected: []
 
-    - description: "Extract valid URL http://www.cp.sc.edu/events/65"
-      text: "test http://www.cp.sc.edu/events/65 test"
-      expected: ["http://www.cp.sc.edu/events/65"]
+    - description: 'DO NOT extract URLs containing underscores in the tld'
+      text: 'test http://twitter.c_o_m'
+      expected: []
 
-    - description: "Extract valid URL http://www.andersondaradio.no.comunidades.net/"
-      text: "http://www.andersondaradio.no.comunidades.net/ test test"
-      expected: ["http://www.andersondaradio.no.comunidades.net/"]
+    - description: 'Extract valid URL http://www.foo.com/foo/path-with-period./'
+      text: 'test http://www.foo.com/foo/path-with-period./'
+      expected: ['http://www.foo.com/foo/path-with-period./']
 
-    - description: "Extract valid URL ELPAÍS.com"
-      text: "test ELPAÍS.com"
-      expected: ["ELPAÍS.com"]
+    - description: 'Extract valid URL http://www.foo.org.za/foo/bar/688.1'
+      text: 'test http://www.foo.org.za/foo/bar/688.1'
+      expected: ['http://www.foo.org.za/foo/bar/688.1']
 
-    - description: "DO NOT include period at the end of URL"
-      text: "test http://twitter.com/."
-      expected: ["http://twitter.com/"]
+    - description: 'Extract valid URL http://www.foo.com/bar-path/some.stm?param1=foo;param2=P1|0||P2|0'
+      text: 'test http://www.foo.com/bar-path/some.stm?param1=foo;param2=P1|0||P2|0'
+      expected:
+        ['http://www.foo.com/bar-path/some.stm?param1=foo;param2=P1|0||P2|0']
+
+    - description: 'Extract valid URL http://foo.com/bar/123/foo_&_bar/'
+      text: 'test http://foo.com/bar/123/foo_&_bar/'
+      expected: ['http://foo.com/bar/123/foo_&_bar/']
+
+    - description: 'Extract valid URL http://www.cp.sc.edu/events/65'
+      text: 'test http://www.cp.sc.edu/events/65 test'
+      expected: ['http://www.cp.sc.edu/events/65']
+
+    - description: 'Extract valid URL http://www.andersondaradio.no.comunidades.net/'
+      text: 'http://www.andersondaradio.no.comunidades.net/ test test'
+      expected: ['http://www.andersondaradio.no.comunidades.net/']
+
+    - description: 'Extract valid URL ELPAÍS.com'
+      text: 'test ELPAÍS.com'
+      expected: ['ELPAÍS.com']
+
+    - description: 'DO NOT include period at the end of URL'
+      text: 'test http://twitter.com/.'
+      expected: ['http://twitter.com/']
 
     - description: "Extract a URL with '?' in fragment"
-      text: "http://tn.com.ar/show/00056158/la-estrella-del-certamen-el-turno-de-pamela-anderson?fb_xd_fragment#?=&cb=fe17523f223b7&relation=parent.parent&transport=fragment&type=resize&height=20&ackdata"
-      expected: ["http://tn.com.ar/show/00056158/la-estrella-del-certamen-el-turno-de-pamela-anderson?fb_xd_fragment#?=&cb=fe17523f223b7&relation=parent.parent&transport=fragment&type=resize&height=20&ackdata"]
+      text: 'http://tn.com.ar/show/00056158/la-estrella-del-certamen-el-turno-de-pamela-anderson?fb_xd_fragment#?=&cb=fe17523f223b7&relation=parent.parent&transport=fragment&type=resize&height=20&ackdata'
+      expected:
+        [
+          'http://tn.com.ar/show/00056158/la-estrella-del-certamen-el-turno-de-pamela-anderson?fb_xd_fragment#?=&cb=fe17523f223b7&relation=parent.parent&transport=fragment&type=resize&height=20&ackdata',
+        ]
 
     - description: "Extract a URL with '?' in fragment in a text"
-      text: "text http://tn.com.ar/show/00056158/la-estrella-del-certamen-el-turno-de-pamela-anderson?fb_xd_fragment#?=&cb=fe17523f223b7&relation=parent.parent&transport=fragment&type=resize&height=20&ackdata text"
-      expected: ["http://tn.com.ar/show/00056158/la-estrella-del-certamen-el-turno-de-pamela-anderson?fb_xd_fragment#?=&cb=fe17523f223b7&relation=parent.parent&transport=fragment&type=resize&height=20&ackdata"]
+      text: 'text http://tn.com.ar/show/00056158/la-estrella-del-certamen-el-turno-de-pamela-anderson?fb_xd_fragment#?=&cb=fe17523f223b7&relation=parent.parent&transport=fragment&type=resize&height=20&ackdata text'
+      expected:
+        [
+          'http://tn.com.ar/show/00056158/la-estrella-del-certamen-el-turno-de-pamela-anderson?fb_xd_fragment#?=&cb=fe17523f223b7&relation=parent.parent&transport=fragment&type=resize&height=20&ackdata',
+        ]
 
-   # A common cause of runaway regex engines.
-    - description: "Extract a URL with a ton of trailing periods"
-      text: "Test a ton of periods http://example.com/path.........................................."
-      expected: ["http://example.com/path"]
+    # A common cause of runaway regex engines.
+    - description: 'Extract a URL with a ton of trailing periods'
+      text: 'Test a ton of periods http://example.com/path..........................................'
+      expected: ['http://example.com/path']
 
-    - description: "Extract a URL with a ton of trailing commas"
-      text: "Test a ton of periods http://example.com/,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,"
-      expected: ["http://example.com/"]
+    - description: 'Extract a URL with a ton of trailing commas'
+      text: 'Test a ton of periods http://example.com/,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,'
+      expected: ['http://example.com/']
 
     - description: "Extract a URL with a ton of trailing '!'"
-      text: "Test a ton of periods http://example.com/path/!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-      expected: ["http://example.com/path/"]
+      text: 'Test a ton of periods http://example.com/path/!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+      expected: ['http://example.com/path/']
 
-    - description: "DO NOT extract URLs in hashtag or @mention"
-      text: "#test.com @test.com #http://test.com @http://test.com #t.co/abcde @t.co/abcde"
+    - description: 'DO NOT extract URLs in hashtag or @mention'
+      text: '#test.com @test.com #http://test.com @http://test.com #t.co/abcde @t.co/abcde'
       expected: []
 
-    - description: "Extract a t.co URL with a trailing apostrophe"
+    - description: 'Extract a t.co URL with a trailing apostrophe'
       text: "I really like http://t.co/pbY2NfTZ's website"
-      expected: ["http://t.co/pbY2NfTZ"]
+      expected: ['http://t.co/pbY2NfTZ']
 
-    - description: "Extract a t.co URL with a trailing hyphen"
+    - description: 'Extract a t.co URL with a trailing hyphen'
       text: "Check this site out http://t.co/FNkPfmii- it's great"
-      expected: ["http://t.co/FNkPfmii"]
+      expected: ['http://t.co/FNkPfmii']
 
-    - description: "Extract a t.co URL with a trailing colon"
-      text: "According to http://t.co/ulYGBYSo: the internet is cool"
-      expected: ["http://t.co/ulYGBYSo"]
+    - description: 'Extract a t.co URL with a trailing colon'
+      text: 'According to http://t.co/ulYGBYSo: the internet is cool'
+      expected: ['http://t.co/ulYGBYSo']
 
-    - description: "Extract URL before newline"
+    - description: 'Extract a t.co URL with a long path'
+      text: 'I really like http://t.co/abcdefghijklmnopqrstuvwxyz0123456789'
+      expected: ['http://t.co/abcdefghijklmnopqrstuvwxyz0123456789']
+
+    - description: 'DO NOT extract URLs with > 40 characters in a t.co slug'
+      text: 'I really like http://t.co/abcdefghijklmnopqrstuvwxyz012345678901234'
+      expected: []
+
+    - description: 'Extract domain followed by Japanese characters'
+      text: 'example.comてすとですtwitter.みんなです'
+      expected: ['example.com', 'twitter.みんな']
+
+    - description: 'Extract URL before newline'
       text: "http://twitter.com\nhttp://example.com\nhttp://example.com/path\nexample.com/path\nit.so\nit.so/abcde"
-      expected: ["http://twitter.com", "http://example.com", "http://example.com/path", "example.com/path", "it.so/abcde"]
+      expected:
+        [
+          'http://twitter.com',
+          'http://example.com',
+          'http://example.com/path',
+          'example.com/path',
+          'it.so',
+          'it.so/abcde',
+        ]
 
-    - description: "DO NOT extract URL if preceded by $"
-      text: "$http://twitter.com $twitter.com $http://t.co/abcde $t.co/abcde $t.co $TVI.CA $RBS.CA"
+    - description: 'DO NOT extract URL if preceded by $'
+      text: '$http://twitter.com $twitter.com $http://t.co/abcde $t.co/abcde $t.co $TVI.CA $RBS.CA'
       expected: []
 
-    - description: "DO NOT extract .bz2 file name as URL"
-      text: "long.test.tar.bz2 test.tar.bz2 tar.bz2"
+    - description: 'DO NOT extract .bz2 file name as URL'
+      text: 'long.test.tar.bz2 test.tar.bz2 tar.bz2'
       expected: []
 
-    - description: "DO NOT extract URL with gTLD followed by @ sign"
-      text: "john.doe.gov@mail.com"
+    - description: 'DO NOT extract URL with gTLD followed by @ sign'
+      text: 'john.doe.gov@mail.com'
       expected: []
 
-    - description: "DO NOT extract URL with ccTLD followed by @ sign"
-      text: "john.doe.jp@mail.com"
+    - description: 'DO NOT extract URL with ccTLD followed by @ sign'
+      text: 'john.doe.jp@mail.com'
       expected: []
 
   urls_with_indices:
-    - description: "Extract a URL"
-      text: "text http://google.com"
+    - description: 'Extract a URL'
+      text: 'text http://google.com'
       expected:
-        - url: "http://google.com"
+        - url: 'http://google.com'
           indices: [5, 22]
 
-    - description: "Extract a URL from a Japanese tweet"
-      text: "皆さん見てください！ http://google.com"
+    - description: 'Extract a URL from a Japanese tweet'
+      text: '皆さん見てください！ http://google.com'
       expected:
-        - url: "http://google.com"
+        - url: 'http://google.com'
           indices: [11, 28]
 
-    - description: "Extract URLs without protocol on ccTLD with slash"
-      text: "t.co/abcde bit.ly/abcde"
+    - description: 'Extract URLs without protocol on ccTLD with slash'
+      text: 't.co/abcde bit.ly/abcde'
       expected:
-        - url: "t.co/abcde"
+        - url: 't.co/abcde'
           indices: [0, 10]
-        - url: "bit.ly/abcde"
+        - url: 'bit.ly/abcde'
           indices: [11, 23]
 
-    - description: "Extract URLs without protocol surrounded by CJK characters"
-      text: "twitter.comこれは日本語です。example.com中国語t.co/abcde한국twitter.com example2.comテストtwitter.com/abcde"
+    - description: 'Extract URLs without protocol surrounded by CJK characters'
+      text: 'twitter.comこれは日本語です。example.com中国語t.co/abcde한국twitter.com example2.comテストtwitter.com/abcde'
       expected:
-        - url: "twitter.com"
+        - url: 'twitter.com'
           indices: [0, 11]
-        - url: "example.com"
+        - url: 'example.com'
           indices: [20, 31]
-        - url: "t.co/abcde"
+        - url: 't.co/abcde'
           indices: [34, 44]
-        - url: "twitter.com"
+        - url: 'twitter.com'
           indices: [46, 57]
-        - url: "example2.com"
+        - url: 'example2.com'
           indices: [58, 70]
-        - url: "twitter.com/abcde"
+        - url: 'twitter.com/abcde'
           indices: [73, 90]
 
-    - description: "Extract URLs with and without protocol surrounded by CJK characters"
-      text: "http://twitter.com/これは日本語です。example.com中国語http://t.co/abcde한국twitter.comテストexample2.comテストhttp://twitter.com/abcde"
+    - description: 'Extract URLs with and without protocol surrounded by CJK characters'
+      text: 'http://twitter.com/これは日本語です。example.com中国語http://t.co/abcde한국twitter.comテストexample2.comテストhttp://twitter.com/abcde'
       expected:
-        - url: "http://twitter.com/"
+        - url: 'http://twitter.com/'
           indices: [0, 19]
-        - url: "example.com"
+        - url: 'example.com'
           indices: [28, 39]
-        - url: "http://t.co/abcde"
+        - url: 'http://t.co/abcde'
           indices: [42, 59]
-        - url: "twitter.com"
+        - url: 'twitter.com'
           indices: [61, 72]
-        - url: "example2.com"
+        - url: 'example2.com'
           indices: [75, 87]
-        - url: "http://twitter.com/abcde"
+        - url: 'http://twitter.com/abcde'
           indices: [90, 114]
 
-    - description: "Extract t.co URLs skipping trailing characters and adjusting indices correctly"
+    - description: 'Extract t.co URLs skipping trailing characters and adjusting indices correctly'
       text: "http://t.co/pbY2NfTZ's http://t.co/2vYHpAc5; http://t.co/ulYGBYSo: http://t.co/8MkmHU0k+c http://t.co/TKLp64dY.x http://t.co/8t7G3ddS#a http://t.co/FNkPfmii-"
       expected:
-        - url: "http://t.co/pbY2NfTZ"
+        - url: 'http://t.co/pbY2NfTZ'
           indices: [0, 20]
-        - url: "http://t.co/2vYHpAc5"
+        - url: 'http://t.co/2vYHpAc5'
           indices: [23, 43]
-        - url: "http://t.co/ulYGBYSo"
+        - url: 'http://t.co/ulYGBYSo'
           indices: [45, 65]
-        - url: "http://t.co/8MkmHU0k"
+        - url: 'http://t.co/8MkmHU0k'
           indices: [67, 87]
-        - url: "http://t.co/TKLp64dY"
+        - url: 'http://t.co/TKLp64dY'
           indices: [90, 110]
-        - url: "http://t.co/8t7G3ddS"
+        - url: 'http://t.co/8t7G3ddS'
           indices: [113, 133]
-        - url: "http://t.co/FNkPfmii"
+        - url: 'http://t.co/FNkPfmii'
           indices: [136, 156]
 
-    - description: "Extract correct indices for duplicate instances of the same URL"
-      text: "http://t.co http://t.co"
+    - description: 'Properly extract URL that contains t.co in referer'
+      text: 'http://www.foo.com?referer=https://t.co/abcde http://t.co/xyzzy'
       expected:
-        - url: "http://t.co"
+        - url: 'http://www.foo.com?referer=https://t.co/abcde'
+          indices: [0, 45]
+        - url: 'http://t.co/xyzzy'
+          indices: [46, 63]
+
+    - description: 'Extract correct indices for duplicate instances of the same URL'
+      text: 'http://t.co http://t.co'
+      expected:
+        - url: 'http://t.co'
           indices: [0, 11]
-        - url: "http://t.co"
+        - url: 'http://t.co'
           indices: [12, 23]
 
-    - description: "Extract I18N URL"
-      text: "test http://xn--ls8h.XN--ls8h.la/"
+    - description: 'Extract I18N URL'
+      text: 'test http://xn--ls8h.XN--ls8h.la/'
       expected:
-        - url: "http://xn--ls8h.XN--ls8h.la/"
+        - url: 'http://xn--ls8h.XN--ls8h.la/'
           indices: [5, 33]
 
-    - description: "Extract URLs with IDN(not encoded)"
-      text: "test http://foobar.みんな/ http://foobar.中国/ http://foobar.پاکستان/ "
+    - description: 'Extract URLs with IDN(not encoded)'
+      text: 'test http://foobar.みんな/ http://foobar.中国/ http://foobar.پاکستان/ '
       expected:
-        - url: "http://foobar.みんな/"
+        - url: 'http://foobar.みんな/'
           indices: [5, 23]
-        - url: "http://foobar.中国/"
+        - url: 'http://foobar.中国/'
           indices: [24, 41]
-        - url: "http://foobar.پاکستان/"
+        - url: 'http://foobar.پاکستان/'
           indices: [42, 64]
 
+  urls_with_directional_markers:
+    - description: 'Extract URLs from RTL text'
+      text: "\U00002066\U0000202Atest abcdef.com پاکستان http://twitter.com/\U0000202C\U00002069"
+      expected:
+        - url: 'abcdef.com'
+          indices: [7, 17]
+        - url: 'http://twitter.com/'
+          indices: [26, 45]
+
+    - description: 'Extract URLs from RTL text with embedded directional marks'
+      text: "This is a test \U00002066\U0000202Atwitter.com\U0000202C\U00002069 \U00002066\U0000202Ahttp://foobar.پاکستان/\U0000202C\U00002069⁩ قطر فلسطين عمان"
+      expected:
+        - url: 'twitter.com'
+          indices: [17, 28]
+        - url: 'http://foobar.پاکستان/'
+          indices: [33, 55]
+
+  tco_urls_with_params:
+    - description: 'Extract valid URL with params: https://t.co/UqIyJAJTfo?amp=1'
+      text: 'text https://t.co/UqIyJAJTfo?amp=1'
+      expected: ['https://t.co/UqIyJAJTfo?amp=1']
+
+    - description: 'Extract valid URL with params: https://t.co/UqIyJAJTfo?type=js'
+      text: 'text https://t.co/UqIyJAJTfo?type=js'
+      expected: ['https://t.co/UqIyJAJTfo?type=js']
+
+    - description: 'Extract valid URL with params: https://t.co/UqIyJAJTfo?ssr=true'
+      text: 'text https://t.co/UqIyJAJTfo?ssr=true'
+      expected: ['https://t.co/UqIyJAJTfo?ssr=true']
+
+    - description: 'Extract a valid URL with params: https://t.co/asdfdf?a=b#123'
+      text: 'text https://t.co/asdfdf?a=b#123'
+      expected: ['https://t.co/asdfdf?a=b#123']
+
+    - description: 'Extract a valid URL with params: https://t.co/sadfasdf?a=b&c=d'
+      text: 'text https://t.co/sadfasdf?a=b&c=d'
+      expected: ['https://t.co/sadfasdf?a=b&c=d']
+
   hashtags:
-    - description: "Extract an all-alpha hashtag"
-      text: "a #hashtag here"
-      expected: ["hashtag"]
+    - description: 'Extract hashtag after emoji without variant selector (uFE0E or uFE0F)'
+      text: 'a ✌#hashtag here'
+      expected: ['hashtag']
 
-    - description: "Extract a letter-then-number hashtag"
-      text: "this is #hashtag1"
-      expected: ["hashtag1"]
+    - description: 'Extract hashtag after emoji with variant selector FE0E'
+      text: 'a ✌︎#hashtag here'
+      expected: ['hashtag']
 
-    - description: "Extract a number-then-letter hashtag"
-      text: "#1hashtag is this"
-      expected: ["1hashtag"]
+    - description: 'Extract hashtag after emoji with variant selector FE0F'
+      text: 'a ✌️#hashtag here'
+      expected: ['hashtag']
 
-    - description: "DO NOT Extract an all-numeric hashtag"
-      text: "On the #16 bus"
+    - description: 'Extract hashtag after emoji with skin tone without variant selector (FE0E or FE0F)'
+      text: 'a ✌🏿#hashtag here'
+      expected: ['hashtag']
+
+    - description: 'Extract hashtag after emoji with skin tone with variant selector FE0F'
+      text: 'a ✌🏿️#hashtag here'
+      expected: ['hashtag']
+
+    - description: 'Extract hashtag after emoji with zero-width-joiner'
+      text: 'a 👨‍👩‍👧#hashtag here'
+      expected: ['hashtag']
+
+    - description: 'Extract an all-alpha hashtag'
+      text: 'a #hashtag here'
+      expected: ['hashtag']
+
+    - description: 'Extract a letter-then-number hashtag'
+      text: 'this is #hashtag1'
+      expected: ['hashtag1']
+
+    - description: 'Extract a number-then-letter hashtag'
+      text: '#1hashtag is this'
+      expected: ['1hashtag']
+
+    - description: 'DO NOT Extract an all-numeric hashtag'
+      text: 'On the #16 bus'
       expected: []
 
-    - description: "DO NOT Extract a single numeric hashtag"
-      text: "#0"
+    - description: 'DO NOT Extract a single numeric hashtag'
+      text: '#0'
       expected: []
 
-    - description: "Extract hashtag after bracket"
-      text: "(#hashtag1 )#hashtag2 [#hashtag3 ]#hashtag4 ’#hashtag5’#hashtag6"
-      expected: ["hashtag1", "hashtag2", "hashtag3", "hashtag4", "hashtag5", "hashtag6"]
+    - description: 'Extract hashtag after bracket'
+      text: '(#hashtag1 )#hashtag2 [#hashtag3 ]#hashtag4 ’#hashtag5’#hashtag6'
+      expected:
+        ['hashtag1', 'hashtag2', 'hashtag3', 'hashtag4', 'hashtag5', 'hashtag6']
 
-    - description: "Extract a hashtag containing ñ"
+    - description: 'Extract a hashtag containing ñ'
       text: "I'll write more tests #mañana"
-      expected: ["mañana"]
+      expected: ['mañana']
 
-    - description: "Extract a hashtag containing é"
-      text: "Working remotely #café"
-      expected: ["café"]
+    - description: 'Extract a hashtag containing é'
+      text: 'Working remotely #café'
+      expected: ['café']
 
-    - description: "Extract a hashtag containing ü"
-      text: "Getting my Oktoberfest on #münchen"
-      expected: ["münchen"]
+    - description: 'Extract a hashtag containing ü'
+      text: 'Getting my Oktoberfest on #münchen'
+      expected: ['münchen']
 
-    - description: "DO NOT Extract a hashtag containing Japanese"
-      text: "this is not valid: # 会議中 ハッシュ"
+    - description: 'DO NOT Extract a hashtag containing Japanese'
+      text: 'this is not valid: # 会議中 ハッシュ'
       expected: []
 
-    - description: "Extract a hashtag in Korean"
-      text: "What is #트위터 anyway?"
-      expected: ["트위터"]
+    - description: 'Extract a hashtag in Korean'
+      text: 'What is #트위터 anyway?'
+      expected: ['트위터']
 
-    - description: "Extract a half-width Hangul hashtag"
-      text: "Just random half-width Hangul #ﾣﾦﾰ"
-      expected: ["ﾣﾦﾰ"]
+    - description: 'Extract a half-width Hangul hashtag'
+      text: 'Just random half-width Hangul #ﾣﾦﾰ'
+      expected: ['ﾣﾦﾰ']
 
-    - description: "Extract a hashtag in Russian"
-      text: "What is #ашок anyway?"
-      expected: ["ашок"]
+    - description: 'Extract a hashtag in Russian'
+      text: 'What is #ашок anyway?'
+      expected: ['ашок']
 
-    - description: "Extract a starting katakana hashtag"
-      text: "#カタカナ is a hashtag"
-      expected: ["カタカナ"]
+    - description: 'Extract a starting katakana hashtag'
+      text: '#カタカナ is a hashtag'
+      expected: ['カタカナ']
 
-    - description: "Extract a starting hiragana hashtag"
-      text: "#ひらがな FTW!"
-      expected: ["ひらがな"]
+    - description: 'Extract a starting hiragana hashtag'
+      text: '#ひらがな FTW!'
+      expected: ['ひらがな']
 
-    - description: "Extract a starting kanji hashtag"
-      text: "#漢字 is the future"
-      expected: ["漢字"]
+    - description: 'Extract a starting kanji hashtag'
+      text: '#漢字 is the future'
+      expected: ['漢字']
 
-    - description: "Extract a trailing katakana hashtag"
-      text: "Hashtag #カタカナ"
-      expected: ["カタカナ"]
+    - description: 'Extract a trailing katakana hashtag'
+      text: 'Hashtag #カタカナ'
+      expected: ['カタカナ']
 
-    - description: "Extract a trailing hiragana hashtag"
-      text: "Japanese hashtags #ひらがな"
-      expected: ["ひらがな"]
+    - description: 'Extract a trailing hiragana hashtag'
+      text: 'Japanese hashtags #ひらがな'
+      expected: ['ひらがな']
 
-    - description: "Extract a trailing kanji hashtag"
-      text: "Study time #漢字"
-      expected: ["漢字"]
+    - description: 'Extract a trailing kanji hashtag'
+      text: 'Study time #漢字'
+      expected: ['漢字']
 
-    - description: "Extract a central katakana hashtag"
-      text: "See my #カタカナ hashtag?"
-      expected: ["カタカナ"]
+    - description: 'Extract a central katakana hashtag'
+      text: 'See my #カタカナ hashtag?'
+      expected: ['カタカナ']
 
-    - description: "Extract a central hiragana hashtag"
-      text: "Study #ひらがな for fun and profit"
-      expected: ["ひらがな"]
+    - description: 'Extract a central hiragana hashtag'
+      text: 'Study #ひらがな for fun and profit'
+      expected: ['ひらがな']
 
-    - description: "Extract a central kanji hashtag"
-      text: "Some say #漢字 is the past. what do they know?"
-      expected: ["漢字"]
+    - description: 'Extract a central kanji hashtag'
+      text: 'Some say #漢字 is the past. what do they know?'
+      expected: ['漢字']
 
-    - description: "Extract a Kanji/Katakana mixed hashtag"
-      text: "日本語ハッシュタグテスト #日本語ハッシュタグ"
-      expected: ["日本語ハッシュタグ"]
+    - description: 'Extract a Kanji/Katakana mixed hashtag'
+      text: '日本語ハッシュタグテスト #日本語ハッシュタグ'
+      expected: ['日本語ハッシュタグ']
 
-    - description: "Extract a hashtag after a punctuation"
-      text: "日本語ハッシュテスト。#日本語ハッシュタグ"
-      expected: ["日本語ハッシュタグ"]
+    - description: 'Extract a hashtag after a punctuation'
+      text: '日本語ハッシュテスト。#日本語ハッシュタグ'
+      expected: ['日本語ハッシュタグ']
 
-    - description: "DO NOT include a punctuation in a hashtag"
-      text: "#日本語ハッシュタグ。"
-      expected: ["日本語ハッシュタグ"]
+    - description: 'DO NOT include a punctuation in a hashtag'
+      text: '#日本語ハッシュタグ。'
+      expected: ['日本語ハッシュタグ']
 
-    - description: "Extract a full-width Alnum hashtag"
-      text: "全角英数字ハッシュタグ ＃ｈａｓｈｔａｇ１２３"
-      expected: ["ｈａｓｈｔａｇ１２３"]
+    - description: 'Extract a full-width Alnum hashtag'
+      text: '全角英数字ハッシュタグ ＃ｈａｓｈｔａｇ１２３'
+      expected: ['ｈａｓｈｔａｇ１２３']
 
-    - description: "DO NOT extract a hashtag without a preceding space"
-      text: "日本語ハッシュタグ#日本語ハッシュタグ"
+    - description: 'DO NOT extract a hashtag without a preceding space'
+      text: '日本語ハッシュタグ#日本語ハッシュタグ'
       expected: []
 
-    - description: "Hashtag with chouon"
-      text: "長音ハッシュタグ。#サッカー"
-      expected: ["サッカー"]
+    - description: 'Hashtag with chouon'
+      text: '長音ハッシュタグ。#サッカー'
+      expected: ['サッカー']
 
-    - description: "Hashtag with half-width chouon"
-      text: "長音ハッシュタグ。#ｻｯｶｰ"
-      expected: ["ｻｯｶｰ"]
+    - description: 'Hashtag with half-width chouon'
+      text: '長音ハッシュタグ。#ｻｯｶｰ'
+      expected: ['ｻｯｶｰ']
 
-    - description: "Hashtag with half-widh voiced sounds marks"
-      text: "#ﾊｯｼｭﾀｸﾞ #ﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ"
-      expected: ["ﾊｯｼｭﾀｸﾞ", "ﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ"]
+    - description: 'Hashtag with half-widh voiced sounds marks'
+      text: '#ﾊｯｼｭﾀｸﾞ #ﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ'
+      expected: ['ﾊｯｼｭﾀｸﾞ', 'ﾊﾟﾋﾟﾌﾟﾍﾟﾎﾟ']
 
-    - description: "Hashtag with half-width # after full-width ！"
-      text: "できましたよー！#日本語ハッシュタグ。"
-      expected: ["日本語ハッシュタグ"]
+    - description: 'Hashtag with half-width # after full-width ！'
+      text: 'できましたよー！#日本語ハッシュタグ。'
+      expected: ['日本語ハッシュタグ']
 
-    - description: "Hashtag with full-width ＃ after full-width ！"
-      text: "できましたよー！＃日本語ハッシュタグ。"
-      expected: ["日本語ハッシュタグ"]
+    - description: 'Hashtag with full-width ＃ after full-width ！'
+      text: 'できましたよー！＃日本語ハッシュタグ。'
+      expected: ['日本語ハッシュタグ']
 
-    - description: "Hashtag with ideographic iteration mark"
-      text: "#云々 #学問のすゝめ #いすゞ #各〻 #各〃"
-      expected: ["云々", "学問のすゝめ", "いすゞ", "各〻", "各〃"]
+    - description: 'Hashtag with ideographic iteration mark'
+      text: '#云々 #学問のすゝめ #いすゞ #各〻 #各〃'
+      expected: ['云々', '学問のすゝめ', 'いすゞ', '各〻', '各〃']
 
-    - description: "Hashtags with ş (U+015F)"
-      text: "Here’s a test tweet for you: #Ateş #qrşt #ştu #ş"
-      expected: ["Ateş", "qrşt", "ştu", "ş"]
+    - description: 'Extract hashtag with fullwidth tilde'
+      text: '#メ～テレ ハッシュタグ内で～が認識されず'
+      expected: ['メ～テレ']
 
-    - description: "Hashtags with İ (U+0130) and ı (U+0131)"
-      text: "Here’s a test tweet for you: #İn #ın"
-      expected: ["İn", "ın"]
+    - description: 'Extract hashtag with wave dash'
+      text: '#メ〜テレ ハッシュタグ内で～が認識されず'
+      expected: ['メ〜テレ']
 
-    - description: "Hashtag before punctuations"
-      text: "#hashtag: #hashtag; #hashtag, #hashtag. #hashtag! #hashtag?"
-      expected: ["hashtag", "hashtag", "hashtag", "hashtag", "hashtag", "hashtag"]
+    - description: 'Hashtags with ş (U+015F)'
+      text: 'Here’s a test tweet for you: #Ateş #qrşt #ştu #ş'
+      expected: ['Ateş', 'qrşt', 'ştu', 'ş']
 
-    - description: "Hashtag after punctuations"
-      text: ":#hashtag ;#hashtag ,#hashtag .#hashtag !#hashtag ?#hashtag"
-      expected: ["hashtag", "hashtag", "hashtag", "hashtag", "hashtag", "hashtag"]
+    - description: 'Hashtags with İ (U+0130) and ı (U+0131)'
+      text: 'Here’s a test tweet for you: #İn #ın'
+      expected: ['İn', 'ın']
 
-    - description: "Hashtag before newline"
+    - description: 'Hashtag before punctuations'
+      text: '#hashtag: #hashtag; #hashtag, #hashtag. #hashtag! #hashtag?'
+      expected:
+        ['hashtag', 'hashtag', 'hashtag', 'hashtag', 'hashtag', 'hashtag']
+
+    - description: 'Hashtag after punctuations'
+      text: ':#hashtag ;#hashtag ,#hashtag .#hashtag !#hashtag ?#hashtag'
+      expected:
+        ['hashtag', 'hashtag', 'hashtag', 'hashtag', 'hashtag', 'hashtag']
+
+    - description: 'Hashtag before newline'
       text: "#hashtag\ntest\n#hashtag2\ntest\n#hashtag3\n"
-      expected: ["hashtag", "hashtag2", "hashtag3"]
+      expected: ['hashtag', 'hashtag2', 'hashtag3']
 
-    - description: "DO NOT extract hashtag when # is followed by URL"
-      text: "#http://twitter.com #https://twitter.com"
+    - description: 'DO NOT extract hashtag when # is followed by URL'
+      text: '#http://twitter.com #https://twitter.com'
       expected: []
 
     - description: "DO NOT extract hashtag if it's a part of URL"
-      text: "http://twitter.com/#hashtag twitter.com/#hashtag"
+      text: 'http://twitter.com/#hashtag twitter.com/#hashtag'
       expected: []
 
-    - description: "Extract hashtags with Latin extended characters"
-      text: "#Azərbaycanca #mûǁae #Čeština #Ċaoiṁín"
-      expected: ["Azərbaycanca", "mûǁae", "Čeština", "Ċaoiṁín"]
+    - description: 'Extract hashtags with Latin extended characters'
+      text: '#Azərbaycanca #mûǁae #Čeština #Ċaoiṁín'
+      expected: ['Azərbaycanca', 'mûǁae', 'Čeština', 'Ċaoiṁín']
 
-    - description: "Extract Arabic hashtags"
-      text: "#سیاست #ایران #السياسة #السياح #لغات  #اتمی  #کنفرانس #العربية #الجزيرة #فارسی"
-      expected: ["سیاست", "ایران", "السياسة", "السياح", "لغات", "اتمی", "کنفرانس", "العربية", "الجزيرة", "فارسی"]
+    - description: 'Extract Arabic hashtags'
+      text: '#سیاست #ایران #السياسة #السياح #لغات  #اتمی  #کنفرانس #العربية #الجزيرة #فارسی'
+      expected:
+        [
+          'سیاست',
+          'ایران',
+          'السياسة',
+          'السياح',
+          'لغات',
+          'اتمی',
+          'کنفرانس',
+          'العربية',
+          'الجزيرة',
+          'فارسی',
+        ]
 
-    - description: "Extract Arabic hashtags with underscore"
-      text: "#برنامه_نویسی  #رییس_جمهور  #رئيس_الوزراء, #ثبت_نام. #لس_آنجلس"
-      expected: ["برنامه_نویسی", "رییس_جمهور", "رئيس_الوزراء", "ثبت_نام", "لس_آنجلس"]
+    - description: 'Extract Arabic hashtags with underscore'
+      text: '#برنامه_نویسی  #رییس_جمهور  #رئيس_الوزراء, #ثبت_نام. #لس_آنجلس'
+      expected:
+        ['برنامه_نویسی', 'رییس_جمهور', 'رئيس_الوزراء', 'ثبت_نام', 'لس_آنجلس']
 
-    - description: "Extract Hebrew hashtags"
-      text: "#עַל־יְדֵי #וכו׳ #מ״כ"
-      expected: ["עַל־יְדֵי", "וכו׳", "מ״כ"]
+    - description: 'Extract Hebrew hashtags'
+      text: '#עַל־יְדֵי #וכו׳ #מ״כ'
+      expected: ['עַל־יְדֵי', 'וכו׳', 'מ״כ']
 
-    - description: "Extract Thai hashtags"
-      text: "#ผู้เริ่ม #การเมือง #รายละเอียด #นักท่องเที่ยว #ของขวัญ #สนามบิน #เดินทาง #ประธาน"
-      expected: ["ผู้เริ่ม", "การเมือง", "รายละเอียด", "นักท่องเที่ยว", "ของขวัญ", "สนามบิน", "เดินทาง", "ประธาน"]
+    - description: 'Extract Thai hashtags'
+      text: '#ผู้เริ่ม #การเมือง #รายละเอียด #นักท่องเที่ยว #ของขวัญ #สนามบิน #เดินทาง #ประธาน'
+      expected:
+        [
+          'ผู้เริ่ม',
+          'การเมือง',
+          'รายละเอียด',
+          'นักท่องเที่ยว',
+          'ของขวัญ',
+          'สนามบิน',
+          'เดินทาง',
+          'ประธาน',
+        ]
 
-    - description: "Extract Arabic hashtags with Zero-Width Non-Joiner"
-      text: "#أي‌بي‌إم #می‌خواهم"
-      expected: ["أي‌بي‌إم", "می‌خواهم"]
+    - description: 'Extract Arabic hashtags with Zero-Width Non-Joiner'
+      text: '#أي‌بي‌إم #می‌خواهم'
+      expected: ['أي‌بي‌إم', 'می‌خواهم']
 
-    - description: "Extract Amharic hashtag"
-      text: "የአላህ መልእክተኛ ሰለላሁ ዓለይሂ ወሰለም #ኢትዮሙስሊምስ"
-      expected: ["ኢትዮሙስሊምስ"]
+    - description: 'Extract Amharic hashtag'
+      text: 'የአላህ መልእክተኛ ሰለላሁ ዓለይሂ ወሰለም #ኢትዮሙስሊምስ'
+      expected: ['ኢትዮሙስሊምስ']
 
-    - description: "Extract Sinhala hashtag with Zero-Width Joiner (U+200D)"
-      text: "#ශ්‍රීලංකා"
-      expected: ["ශ්‍රීලංකා"]
+    - description: 'Extract Sinhala hashtag with Zero-Width Joiner (U+200D)'
+      text: '#ශ්‍රීලංකා'
+      expected: ['ශ්‍රීලංකා']
 
-    - description: "Extract Arabic and Persian hashtags with numbers"
-      text: "#۳۴۵هشتگ #هشتگ۶۷۸ #ســـلام_عليكم_٤٠٦"
-      expected: ["۳۴۵هشتگ","هشتگ۶۷۸","ســـلام_عليكم_٤٠٦"]
+    - description: 'Extract Arabic and Persian hashtags with numbers'
+      text: '#۳۴۵هشتگ #هشتگ۶۷۸ #ســـلام_عليكم_٤٠٦'
+      expected: ['۳۴۵هشتگ', 'هشتگ۶۷۸', 'ســـلام_عليكم_٤٠٦']
 
-    - description: "Extract Hindi hashtags"
-      text: "#महात्मा #महात्मा_१२३४ #१२३४ गांधी"
-      expected: ["महात्मा","महात्मा_१२३४"]
+    - description: 'Extract Hindi hashtags'
+      text: '#महात्मा #महात्मा_१२३४ #१२३४ गांधी'
+      expected: ['महात्मा', 'महात्मा_१२३४']
 
-    - description: "Extract Indic script hashtags"
-      text: "#বাংলা #ગુજરાતી #ಕನ್ನಡ #മലയാളം #ଓଡ଼ିଆ #ਪੰਜਾਬੀ #සිංහල #தமிழ் #తెలుగు"
-      expected: ["বাংলা","ગુજરાતી","ಕನ್ನಡ","മലയാളം","ଓଡ଼ିଆ","ਪੰਜਾਬੀ","සිංහල","தமிழ்","తెలుగు"]
+    - description: 'Extract Indic script hashtags'
+      text: '#বাংলা #ગુજરાતી #ಕನ್ನಡ #മലയാളം #ଓଡ଼ିଆ #ਪੰਜਾਬੀ #සිංහල #தமிழ் #తెలుగు'
+      expected:
+        [
+          'বাংলা',
+          'ગુજરાતી',
+          'ಕನ್ನಡ',
+          'മലയാളം',
+          'ଓଡ଼ିଆ',
+          'ਪੰਜਾਬੀ',
+          'සිංහල',
+          'தமிழ்',
+          'తెలుగు',
+        ]
 
-    - description: "Extract Tibetan hashtags"
-      text: "#བོད་སྐད་ #བོད་སྐད"
-      expected: ["བོད་སྐད་","བོད་སྐད"]
+    - description: 'Extract Tibetan hashtags'
+      text: '#བོད་སྐད་ #བོད་སྐད'
+      expected: ['བོད་སྐད་', 'བོད་སྐད']
 
-    - description: "Extract Khmer, Burmese, Laotian hashtags"
-      text: "#មហាត្មះគន្ធី #မြင့်မြတ်သော #ຊີວະສາດ"
-      expected: ["មហាត្មះគន្ធី","မြင့်မြတ်သော","ຊີວະສາດ"]
+    - description: 'Extract Khmer, Burmese, Laotian hashtags'
+      text: '#មហាត្មះគន្ធី #မြင့်မြတ်သော #ຊີວະສາດ'
+      expected: ['មហាត្មះគន្ធី', 'မြင့်မြတ်သော', 'ຊີວະສາດ']
 
-    - description: "Extract Greek hashtag"
-      text: "#Μαχάτμα_Γκάντι ήταν Ινδός πολιτικός"
-      expected: ["Μαχάτμα_Γκάντι"]
+    - description: 'Extract Greek hashtag'
+      text: '#Μαχάτμα_Γκάντι ήταν Ινδός πολιτικός'
+      expected: ['Μαχάτμα_Γκάντι']
 
-    - description: "Extract Armenian and Georgian hashtags"
-      text: "#Մահաթմա #მაჰათმა"
-      expected: ["Մահաթմա","მაჰათმა"]
+    - description: 'Extract Armenian and Georgian hashtags'
+      text: '#Մահաթմա #მაჰათმა'
+      expected: ['Մահաթմա', 'მაჰათმა']
 
-    - description: "Extract hashtag with middle dot"
-      text: "#il·lusió"
-      expected: ["il·lusió"]
+    - description: 'Extract hashtag with middle dot'
+      text: '#il·lusió'
+      expected: ['il·lusió']
 
-    - description: "DO NOT extract hashtags without a letter"
-      text: "#_ #1_2 #122 #〃"
+    - description: 'DO NOT extract hashtags without a letter'
+      text: '#_ #1_2 #122 #〃'
       expected: []
+
+  hashtags_from_astral:
+    - description: 'Extract hashtag with letter from astral plane (U+20021)'
+      text: "#\U00020021"
+      expected: ["\U00020021"]
+
+    - description: 'Extract hashtag with letter plus marker from astral plane (U+16f04 U+16f51)'
+      text: "#\U00016f04\U00016f51"
+      expected: ["\U00016f04\U00016f51"]
+
+    - description: 'Extract hashtag with letter plus number from astral plane (U+104a0)'
+      text: "#\U00000041\U000104a0"
+      expected: ["A\U000104a0"]
 
   hashtags_with_indices:
-    - description: "Extract a hastag at the start"
-      text: "#hashtag here"
+    - description: 'Extract a hastag at the start'
+      text: '#hashtag here'
       expected:
-        - hashtag: "hashtag"
+        - hashtag: 'hashtag'
           indices: [0, 8]
 
-    - description: "Extract a hastag at the end"
-      text: "test a #hashtag"
+    - description: 'Extract a hastag at the end'
+      text: 'test a #hashtag'
       expected:
-        - hashtag: "hashtag"
+        - hashtag: 'hashtag'
           indices: [7, 15]
 
-    - description: "Extract a hastag in the middle"
-      text: "test a #hashtag in a string"
+    - description: 'Extract a hastag in the middle'
+      text: 'test a #hashtag in a string'
       expected:
-        - hashtag: "hashtag"
+        - hashtag: 'hashtag'
           indices: [7, 15]
 
-    - description: "Extract only a valid hashtag"
-      text: "#123 a #hashtag in a string"
+    - description: 'Extract only a valid hashtag'
+      text: '#123 a #hashtag in a string'
       expected:
-        - hashtag: "hashtag"
+        - hashtag: 'hashtag'
           indices: [7, 15]
 
-    - description: "Extract a hashtag in a string of multi-byte characters"
-      text: "会議中 #hashtag 会議中"
+    - description: 'Extract a hashtag in a string of multi-byte characters'
+      text: '会議中 #hashtag 会議中'
       expected:
-        - hashtag: "hashtag"
+        - hashtag: 'hashtag'
           indices: [4, 12]
 
-    - description: "Extract multiple valid hashtags"
-      text: "One #two three #four"
+    - description: 'Extract multiple valid hashtags'
+      text: 'One #two three #four'
       expected:
-        - hashtag: "two"
+        - hashtag: 'two'
           indices: [4, 8]
-        - hashtag: "four"
+        - hashtag: 'four'
           indices: [15, 20]
 
-    - description: "Extract a non-latin hashtag"
-      text: "Hashtags in #русский!"
+    - description: 'Extract a non-latin hashtag'
+      text: 'Hashtags in #русский!'
       expected:
-        - hashtag: "русский"
+        - hashtag: 'русский'
           indices: [12, 20]
 
-    - description: "Extract multiple non-latin hashtags"
-      text: "Hashtags in #中文, #日本語, #한국말, and #русский! Try it out!"
+    - description: 'Extract multiple non-latin hashtags'
+      text: 'Hashtags in #中文, #日本語, #한국말, and #русский! Try it out!'
       expected:
-        - hashtag: "中文"
+        - hashtag: '中文'
           indices: [12, 15]
-        - hashtag: "日本語"
+        - hashtag: '日本語'
           indices: [17, 21]
-        - hashtag: "한국말"
+        - hashtag: '한국말'
           indices: [23, 27]
-        - hashtag: "русский"
+        - hashtag: 'русский'
           indices: [33, 41]
 
   cashtags:
-    - description: "Extract cashtags"
-      text: "Example cashtags: $TEST $Stock   $symbol"
-      expected: ["TEST", "Stock", "symbol"]
+    - description: 'Extract cashtags'
+      text: 'Example cashtags: $TEST $Stock   $symbol'
+      expected: ['TEST', 'Stock', 'symbol']
 
-    - description: "Extract cashtags with . or _"
-      text: "Example cashtags: $TEST.T $test.tt $Stock_X $symbol_ab"
-      expected: ["TEST.T", "test.tt", "Stock_X", "symbol_ab"]
+    - description: 'Extract cashtags with . or _'
+      text: 'Example cashtags: $TEST.T $test.tt $Stock_X $symbol_ab'
+      expected: ['TEST.T', 'test.tt', 'Stock_X', 'symbol_ab']
 
-    - description: "Do not extract cashtags if they contain numbers"
-      text: "$123 $test123 $TE123ST"
+    - description: 'Do not extract cashtags if they contain numbers'
+      text: '$123 $test123 $TE123ST'
       expected: []
 
-    - description: "Do not extract cashtags with non-ASCII characters"
-      text: "$ストック $株"
+    - description: 'Do not extract cashtags with non-ASCII characters'
+      text: '$ストック $株'
       expected: []
 
-    - description: "Do not extract cashtags with punctuations"
-      text: "$ $. $- $@ $! $() $+"
+    - description: 'Do not extract cashtags with punctuations'
+      text: '$ $. $- $@ $! $() $+'
       expected: []
 
-    - description: "Do not include trailing . or _"
-      text: "$TEST. $TEST_"
-      expected: ["TEST", "TEST"]
+    - description: 'Do not include trailing . or _'
+      text: '$TEST. $TEST_'
+      expected: ['TEST', 'TEST']
 
-    - description: "Do not extract cashtags if there is no space before $"
-      text: "$OK$NG$BAD text$NO .$NG $$NG"
-      expected: ["OK"]
+    - description: 'Do not extract cashtags if there is no space before $'
+      text: '$OK$NG$BAD text$NO .$NG $$NG'
+      expected: ['OK']
 
-    - description: "Do not extract too long cashtags"
-      text: "$CashtagMustBeLessThanSixCharacter"
+    - description: 'Do not extract too long cashtags'
+      text: '$CashtagMustBeLessThanSixCharacter'
       expected: []
 
   cashtags_with_indices:
-    - description: "Extract cashtags"
-      text: "Example: $TEST $symbol test"
+    - description: 'Extract cashtags'
+      text: 'Example: $TEST $symbol test'
       expected:
-        - cashtag: "TEST"
+        - cashtag: 'TEST'
           indices: [9, 14]
-        - cashtag: "symbol"
+        - cashtag: 'symbol'
           indices: [15, 22]
 
-    - description: "Extract cashtags with . or _"
-      text: "Example: $TEST.T test $symbol_ab end"
+    - description: 'Extract cashtags with . or _'
+      text: 'Example: $TEST.T test $symbol_ab end'
       expected:
-        - cashtag: "TEST.T"
+        - cashtag: 'TEST.T'
           indices: [9, 16]
-        - cashtag: "symbol_ab"
+        - cashtag: 'symbol_ab'
           indices: [22, 32]

--- a/conformance/validate.yml
+++ b/conformance/validate.yml
@@ -1,244 +1,705 @@
-
 tests:
   tweets:
-    - description: "Valid Tweet: < 20 characters"
-      text: "I am a Tweet"
+    - description: 'Valid Tweet: < 20 characters'
+      text: 'I am a Tweet'
       expected: true
 
-    - description: "Valid Tweet: 140 characters"
-      text: "A lie gets halfway around the world before the truth has a chance to get its pants on. Winston Churchill (1874-1965) http://bit.ly/dJpywL"
+    - description: 'Valid Tweet: 140 characters'
+      text: 'A lie gets halfway around the world before the truth has a chance to get its pants on. Winston Churchill (1874-1965) http://bit.ly/dJpywL'
       expected: true
 
-    - description: "Valid Tweet: 140 characters (with accents)"
-      text: "A lié géts halfway arøünd thé wørld béføré thé truth has a chance tø get its pants øn. Winston Churchill (1874-1965) http://bit.ly/dJpywL"
+    - description: 'Valid Tweet: 140 characters (with accents)'
+      text: 'A lié géts halfway arøünd thé wørld béføré thé truth has a chance tø get its pants øn. Winston Churchill (1874-1965) http://bit.ly/dJpywL'
       expected: true
 
-    - description: "Valid Tweet: 140 characters (double byte characters)"
-      text: "のののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののの"
+    - description: 'Valid Tweet: 140 characters (double byte characters)'
+      text: 'のののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののののの'
       expected: true
 
-    - description: "Valid Tweet: 140 characters (double word characters)"
+    - description: 'Valid Tweet: 140 characters (double word characters)'
       text: "\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431\U0001f431"
       expected: true
 
-    - description: "Invalid Tweet: no characters (empty)"
-      text: ""
+    - description: 'Invalid Tweet: no characters (empty)'
+      text: ''
       expected: false
 
-    - description: "Invalid Tweet: 141 characters"
-      text: "A lie gets halfway around the world before the truth has a chance to get its pants on. -- Winston Churchill (1874-1965) http://bit.ly/dJpywL"
+    - description: 'Invalid Tweet: 141 characters'
+      text: 'A lie gets halfway around the world before the truth has a chance to get its pants on. -- Winston Churchill (1874-1965) http://bit.ly/dJpywL'
       expected: false
 
-    - description: "Invalid Tweet: 141 characters (due to newline)"
+    - description: 'Invalid Tweet: 141 characters (due to newline)'
       text: "A lie gets halfway around the world before the truth has a chance to get its pants on. \n- Winston Churchill (1874-1965) http://bit.ly/dJpywL"
       expected: false
 
   usernames:
-    - description: "Valid username: a-z < 20 characters"
-      text: "@username"
+    - description: 'Valid username: a-z < 20 characters'
+      text: '@username'
       expected: true
 
-    - description: "All numeric username are allowed"
-      text: "@12345"
+    - description: 'All numeric username are allowed'
+      text: '@12345'
       expected: true
 
-    - description: "Usernames should allow the _ character"
-      text: "@example_name"
+    - description: 'Usernames should allow the _ character'
+      text: '@example_name'
       expected: true
 
-    - description: "Usernames SHOULD NOT allow the - character"
-      text: "@example-name"
+    - description: 'Usernames SHOULD NOT allow the - character'
+      text: '@example-name'
       expected: false
 
   lists:
-    - description: "Valid list: a-z < 20 characters"
-      text: "@username/list"
+    - description: 'Valid list: a-z < 20 characters'
+      text: '@username/list'
       expected: true
 
-    - description: "A username alone SHOULD NOT be considered a valid list"
-      text: "@username"
+    - description: 'A username alone SHOULD NOT be considered a valid list'
+      text: '@username'
       expected: false
 
-    - description: "A username followed by a slash SHOULD NOT be considered a valid list"
-      text: "@username/"
+    - description: 'A username followed by a slash SHOULD NOT be considered a valid list'
+      text: '@username/'
       expected: false
 
-    - description: "Validation SHOULD NOT allow leading spaces"
-      text: " @username/list"
+    - description: 'Validation SHOULD NOT allow leading spaces'
+      text: ' @username/list'
       expected: false
 
-    - description: "Validation SHOULD NOT allow trailing spaces"
-      text: "@username/list "
+    - description: 'Validation SHOULD NOT allow trailing spaces'
+      text: '@username/list '
       expected: false
 
   hashtags:
-    - description: "Valid hashtag: a-z < 20 characters"
-      text: "#hashtag"
+    - description: 'Valid hashtag: a-z < 20 characters'
+      text: '#hashtag'
       expected: true
 
-    - description: "Valid hashtag: number followed by letters"
-      text: "#1st"
+    - description: 'Valid hashtag: number followed by letters'
+      text: '#1st'
       expected: true
 
-    - description: "Valid hashtag: letters and numbers mixed"
-      text: "#that1time"
+    - description: 'Valid hashtag: letters and numbers mixed'
+      text: '#that1time'
       expected: true
 
-    - description: "Valid hashtag: letter followed by numbers"
-      text: "#easyas123"
+    - description: 'Valid hashtag: letter followed by numbers'
+      text: '#easyas123'
       expected: true
 
-    - description: "Invalid hashtag: all numbers"
-      text: "#12345"
+    - description: 'Invalid hashtag: all numbers'
+      text: '#12345'
       expected: false
 
-    - description: "Valid hashtag: Russian text"
-      text: "#ашок"
+    - description: 'Valid hashtag: Russian text'
+      text: '#ашок'
       expected: true
 
-    - description: "Valid hashtag: Korean text"
-      text: "#트위터"
+    - description: 'Valid hashtag: Korean text'
+      text: '#트위터'
       expected: true
 
   urls:
-    - description: "Valid url: protocol + domain"
-      text: "http://example.com"
+    - description: 'Valid url: protocol + domain'
+      text: 'http://example.com'
       expected: true
 
-    - description: "Valid url: ssl + domain + path + query"
-      text: "https://example.com/path/to/resource?search=foo&lang=en"
+    - description: 'Valid url: ssl + domain + path + query'
+      text: 'https://example.com/path/to/resource?search=foo&lang=en'
       expected: true
 
-    - description: "Valid url: protocol + domain + path + fragment"
-      text: "http://twitter.com/#!/twitter"
+    - description: 'Valid url: protocol + domain + path + fragment'
+      text: 'http://twitter.com/#!/twitter'
       expected: true
 
-    - description: "Valid url: cased protocol and domain"
-      text: "HTTPS://www.ExaMPLE.COM/index.html"
+    - description: 'Valid url: cased protocol and domain'
+      text: 'HTTPS://www.ExaMPLE.COM/index.html'
       expected: true
 
-    - description: "Valid url: port and userinfo"
-      text: "http://user:PASSW0RD@example.com:8080/login.php"
+    - description: 'Valid url: port and userinfo'
+      text: 'http://user:PASSW0RD@example.com:8080/login.php'
       expected: true
 
-    - description: "Valid url: matrix path parameters"
-      text: "http://sports.yahoo.com/nfl/news;_ylt=Aom0;ylu=XyZ?slug=ap-superbowlnotebook"
+    - description: 'Valid url: matrix path parameters'
+      text: 'http://sports.yahoo.com/nfl/news;_ylt=Aom0;ylu=XyZ?slug=ap-superbowlnotebook'
       expected: true
 
-    - description: "Valid url: ipv4"
-      text: "http://192.168.0.1/index.html?src=asdf"
+    - description: 'Valid url: ipv4'
+      text: 'http://192.168.0.1/index.html?src=asdf'
       expected: true
 
-    - description: "Valid url: ipv6"
-      text: "http://[3ffe:1900:4545:3:200:f8ff:fe21:67cf]:80/index.html"
+    - description: 'Valid url: ipv6'
+      text: 'http://[3ffe:1900:4545:3:200:f8ff:fe21:67cf]:80/index.html'
       expected: true
 
-    - description: "Valid url: underscore in subdomain"
-      text: "http://test_underscore.twitter.com"
+    - description: 'Valid url: underscore in subdomain'
+      text: 'http://test_underscore.twitter.com'
       expected: true
 
-    - description: "Valid url: sub delims and question marks"
-      text: "http://example.com?foo=$bar.;baz?BAZ&c=d-#top/?stories+"
+    - description: 'Valid url: sub delims and question marks'
+      text: 'http://example.com?foo=$bar.;baz?BAZ&c=d-#top/?stories+'
       expected: true
 
-    - description: "Valid unicode url: unicode domain"
-      text: "http://☃.net/"
+    - description: 'Valid unicode url: unicode domain'
+      text: 'http://☃.net/'
       expected: true
 
-    - description: "Valid url: trailing hyphen"
-      text: "https://www.youtube.com/playlist?list=PL0ZPu8XSRTB7wZzn0mLHMvyzVFeRxbWn-"
+    - description: 'Valid url: Cyrillic characters in path'
+      text: 'http://example.com/Русские_слова'
       expected: true
 
-    - description: "Invalid url: invalid scheme"
-      text: "ftp://www.example.com/"
+    - description: 'Valid url: trailing hyphen'
+      text: 'https://www.youtube.com/playlist?list=PL0ZPu8XSRTB7wZzn0mLHMvyzVFeRxbWn-'
+      expected: true
+
+    - description: 'Invalid url: invalid scheme'
+      text: 'ftp://www.example.com/'
       expected: false
 
-    - description: "Invalid url: invalid userinfo characters"
-      text: "https://user:pass[word]@www.example.com/"
+    - description: 'Invalid url: invalid userinfo characters'
+      text: 'https://user:pass[word]@www.example.com/'
       expected: false
 
-    - description: "Invalid url: underscore in domain"
-      text: "http://domain-dash_2314352345_dfasd.foo-cow_4352.com"
+    - description: 'Invalid url: underscore in domain'
+      text: 'http://domain-dash_2314352345_dfasd.foo-cow_4352.com'
       expected: false
 
-    - description: "Invalid url: domain beginning dash"
-      text: "http://www.-domain4352.com/"
+    - description: 'Invalid url: domain beginning dash'
+      text: 'http://www.-domain4352.com/'
       expected: false
 
-    - description: "Invalid url: domain trailing dash"
-      text: "http://www.domain4352-.com/"
+    - description: 'Invalid url: domain trailing dash'
+      text: 'http://www.domain4352-.com/'
       expected: false
 
-    - description: "Invalid url: unicode domain trailing dash"
-      text: "http://☃-.net/"
+    - description: 'Invalid url: unicode domain trailing dash'
+      text: 'http://☃-.net/'
       expected: false
 
-    - description: "Invalid url: improperly encoded unicode domain"
-      text: "http://%e2%98%83.net/"
+    - description: 'Invalid url: improperly encoded unicode domain'
+      text: 'http://%e2%98%83.net/'
       expected: false
 
-    - description: "Invalid url: invalid IP"
-      text: "http://256.1.2.3/"
+    - description: 'Invalid url: invalid IP'
+      text: 'http://256.1.2.3/'
       expected: false
 
-    - description: "Invalid url: invalid char in path"
-      text: "http://en.wikipedia.org/wiki/\"#Punctuation"
+    - description: 'Invalid url: invalid char in path'
+      text: 'http://en.wikipedia.org/wiki/"#Punctuation'
       expected: false
 
-    - description: "Invalid url: trailing space"
-      text: "http://example.com/#anchor "
+    - description: 'Invalid url: trailing space'
+      text: 'http://example.com/#anchor '
+      expected: false
+
+    - description: 'Invalid url: domain has leading hyphen'
+      text: 'http://test.-twitter.com'
       expected: false
 
   urls_without_protocol:
-    - description: "Valid url without protocol: domain + gTLD"
-      text: "example.com"
+    - description: 'Valid url without protocol: domain + gTLD'
+      text: 'example.com'
       expected: true
 
-    - description: "Valid url without protocol: subdomain + domain + gTLD"
-      text: "www.example.com"
+    - description: 'Valid url without protocol: subdomain + domain + gTLD'
+      text: 'www.example.com'
       expected: true
 
-    - description: "Valid url without protocol: domain + ccTLD"
-      text: "t.co"
+    - description: 'Valid url without protocol: domain + ccTLD'
+      text: 't.co'
       expected: true
 
-    - description: "Valid url without protocol: subdomain + domain + ccTLD"
-      text: "foo.co.jp"
+    - description: 'Valid url without protocol: subdomain + domain + ccTLD'
+      text: 'foo.co.jp'
       expected: true
 
-    - description: "Valid url without protocol: domain + path + query"
-      text: "example.com/path/to/resource?search=foo&lang=en"
+    - description: 'Valid url without protocol: domain + path + query'
+      text: 'example.com/path/to/resource?search=foo&lang=en'
       expected: true
 
-  lengths:
-    - description: "Count the number of characters"
-      text: "This is a test."
-      expected: 15
+  WeightedTweetsCounterTest:
+    - description: 'Regular Tweet with url'
+      text: 'Hi http://test.co'
+      expected:
+        weightedLength: 26
+        valid: true
+        permillage: 92
+        displayRangeStart: 0
+        displayRangeEnd: 16
+        validRangeStart: 0
+        validRangeEnd: 16
 
-    - description: "Count a URL starting with http:// as 23 characters"
-      text: "http://test.com"
-      expected: 23
+    - description: 'Just url'
+      text: 'http://test.co'
+      expected:
+        weightedLength: 23
+        valid: true
+        permillage: 82
+        displayRangeStart: 0
+        displayRangeEnd: 13
+        validRangeStart: 0
+        validRangeEnd: 13
 
-    - description: "Count a URL starting with https:// as 23 characters"
-      text: "https://test.com"
-      expected: 23
+    - description: 'Long tweet, overflow at char index 280'
+      text: '285 chars-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-'
+      expected:
+        weightedLength: 285
+        valid: false
+        permillage: 1017
+        displayRangeStart: 0
+        displayRangeEnd: 284
+        validRangeStart: 0
+        validRangeEnd: 279
 
-    - description: "Count a URL without protocol as 23 characters"
-      text: "test.com"
-      expected: 23
+    - description: 'Long tweet with url in the middle, overflow at char index 284'
+      text: '285 chars- http://www.twitter.com/jack xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-'
+      expected:
+        weightedLength: 299
+        valid: false
+        permillage: 1067
+        displayRangeStart: 0
+        displayRangeEnd: 302
+        validRangeStart: 0
+        validRangeEnd: 283
 
-    - description: "Count multiple URLs correctly"
-      text: "Test https://test.com test https://test.com test.com test"
-      expected: 86
+    - description: 'Long tweet with url at the end, overflow at char index 265'
+      text: 'xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx- http://www.twitter.com/jack '
+      expected:
+        weightedLength: 289
+        valid: false
+        permillage: 1032
+        displayRangeStart: 0
+        displayRangeEnd: 292
+        validRangeStart: 0
+        validRangeEnd: 264
 
-    - description: "Count unicode chars outside the basic multilingual plane (double word)"
-      text: "\U00010000\U0010ffff"
-      expected: 2
+    - description: '10 url string, no overflow'
+      text: 'https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha '
+      expected:
+        weightedLength: 240
+        valid: true
+        permillage: 857
+        displayRangeStart: 0
+        displayRangeEnd: 299
+        validRangeStart: 0
+        validRangeEnd: 299
 
-    - description: "Count unicode chars inside the basic multilingual plane"
-      text: "저찀쯿쿿"
-      expected: 4
+    - description: '160 CJK char, overflow at char index 140'
+      text: '故人西辞黄鹤楼，烟花三月下扬州。孤帆远影碧空尽，唯见长江天际流。朱雀桥边野草花，乌衣巷口夕阳斜。旧时王谢堂前燕，飞入寻常百姓家。朝辞白帝彩云间，千里江陵一日还。两岸猿声啼不住，轻舟已过万重山。泪湿罗巾梦不成，夜深前殿按歌声。红颜未老恩先断，斜倚薰笼坐到明。独在异乡为异客，每逢佳节倍思亲。遥知兄弟登高处，遍插茱萸少一人。'
+      expected:
+        weightedLength: 320
+        valid: false
+        permillage: 1142
+        displayRangeStart: 0
+        displayRangeEnd: 159
+        validRangeStart: 0
+        validRangeEnd: 139
 
-    - description: "Count a mix of single byte single word, and double word unicode characters"
-      text: "H\U0001f431☺"
-      expected: 3
+    - description: '160 emoji char, overflow at char index 140'
+      text: '😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷'
+      expected:
+        weightedLength: 320
+        valid: false
+        permillage: 1142
+        displayRangeStart: 0
+        displayRangeEnd: 319
+        validRangeStart: 0
+        validRangeEnd: 279
+
+    - description: '3 latin char + 160 CJK char, overflow at char index 141'
+      text: 'the故人西辞黄鹤楼，烟花三月下扬州。孤帆远影碧空尽，唯见长江天际流。朱雀桥边野草花，乌衣巷口夕阳斜。旧时王谢堂前燕，飞入寻常百姓家。朝辞白帝彩云间，千里江陵一日还。两岸猿声啼不住，轻舟已过万重山。泪湿罗巾梦不成，夜深前殿按歌声。红颜未老恩先断，斜倚薰笼坐到明。独在异乡为异客，每逢佳节倍思亲。遥知兄弟登高处，遍插茱萸少一人。'
+      expected:
+        weightedLength: 323
+        valid: false
+        permillage: 1153
+        displayRangeStart: 0
+        displayRangeEnd: 162
+        validRangeStart: 0
+        validRangeEnd: 140
+
+    - description: "'Á' is normalized into 1 char"
+      text: 'ÁB'
+      expected:
+        weightedLength: 2
+        valid: true
+        permillage: 7
+        displayRangeStart: 0
+        displayRangeEnd: 2
+        validRangeStart: 0
+        validRangeEnd: 2
+
+    - description: 'שּׁ is normalized into 3 chars'
+      text: 'Aשּׁ'
+      expected:
+        weightedLength: 4
+        valid: true
+        permillage: 14
+        displayRangeStart: 0
+        displayRangeEnd: 1
+        validRangeStart: 0
+        validRangeEnd: 1
+
+    - description: '282 chars with a normalized character within valid range but outside 280'
+      text: '282 chars-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxÁx'
+      expected:
+        weightedLength: 281
+        valid: false
+        permillage: 1003
+        displayRangeStart: 0
+        displayRangeEnd: 281
+        validRangeStart: 0
+        validRangeEnd: 280
+
+    - description: 'Count a mix of single byte single word, and double word unicode characters'
+      text: 'H🐱☺👨‍👩‍👧‍👦'
+      expected:
+        weightedLength: 16
+        valid: true
+        permillage: 57
+        displayRangeStart: 0
+        displayRangeEnd: 14
+        validRangeStart: 0
+        validRangeEnd: 14
+
+    - description: 'Count unicode emoji chars inside the basic multilingual plane'
+      text: '😷👾😡🔥💩'
+      expected:
+        weightedLength: 10
+        valid: true
+        permillage: 35
+        displayRangeStart: 0
+        displayRangeEnd: 9
+        validRangeStart: 0
+        validRangeEnd: 9
+
+    - description: 'Count unicode emoji chars outside the basic multilingual plane with skin tone modifiers'
+      text: '🙋🏽👨‍🎤'
+      expected:
+        weightedLength: 9
+        valid: true
+        permillage: 32
+        displayRangeStart: 0
+        displayRangeEnd: 8
+        validRangeStart: 0
+        validRangeEnd: 8
+
+    - description: 'Handle General Punctuation Characters with visible spaces(u2000-200A)'
+      text: "This is a tweet with general punctuation characters: \u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u200B\u200C\u200D ‐ ‑ ‒ – — ― ‖  ‗ ‘ ’ ‚ ‛ “ ” „ ‟ ′ ″ ‴ ‵ ‶ ‷"
+      expected:
+        weightedLength: 112
+        valid: true
+        permillage: 400
+        displayRangeStart: 0
+        displayRangeEnd: 111
+        validRangeStart: 0
+        validRangeEnd: 111
+
+    - description: 'Handle long url with invalid domain labels and short url'
+      text: 'Long url with invalid domain labels and a short url: https://somesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurl.com/foo https://somesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurl.com/foo https://somesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurl.com/foo https://validurl.com'
+      expected:
+        weightedLength: 12079
+        valid: false
+        permillage: 43139
+        displayRangeStart: 0
+        displayRangeEnd: 12075
+        validRangeStart: 0
+        validRangeEnd: 279
+
+    - description: 'Handle a 64 character domain without protocol'
+      text: 'randomurlrandomurlrandomurlrandomurlrandomurlrandomurlrandomurls.com'
+      expected:
+        weightedLength: 68
+        valid: true
+        permillage: 242
+        displayRangeStart: 0
+        displayRangeEnd: 67
+        validRangeStart: 0
+        validRangeEnd: 67
+
+    - description: 'Do not allow > 140 CJK characters by virtue of CJK chars greater than 63 punycode encoded chars in the host'
+      text: 'あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこ http://あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいう.com'
+      expected:
+        weightedLength: 358
+        valid: false
+        permillage: 1278
+        displayRangeStart: 0
+        displayRangeEnd: 184
+        validRangeStart: 0
+        validRangeEnd: 143
+
+    - description: 'Allow > 140 CJK characters by virtue of CJK chars less than 63 punycode encoded chars in the host'
+      text: 'あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこ http://あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあい.com'
+      expected:
+        weightedLength: 264
+        valid: true
+        permillage: 942
+        displayRangeStart: 0
+        displayRangeEnd: 183
+        validRangeStart: 0
+        validRangeEnd: 183
+
+  WeightedTweetsWithDiscountedEmojiCounterTest:
+    - description: 'Regular Tweet with url'
+      text: 'Hi http://test.co'
+      expected:
+        weightedLength: 26
+        valid: true
+        permillage: 92
+        displayRangeStart: 0
+        displayRangeEnd: 16
+        validRangeStart: 0
+        validRangeEnd: 16
+
+    - description: 'Just url'
+      text: 'http://test.co'
+      expected:
+        weightedLength: 23
+        valid: true
+        permillage: 82
+        displayRangeStart: 0
+        displayRangeEnd: 13
+        validRangeStart: 0
+        validRangeEnd: 13
+
+    - description: 'Long tweet, overflow at char index 280'
+      text: '285 chars-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-'
+      expected:
+        weightedLength: 285
+        valid: false
+        permillage: 1017
+        displayRangeStart: 0
+        displayRangeEnd: 284
+        validRangeStart: 0
+        validRangeEnd: 279
+
+    - description: 'Long tweet with url in the middle, overflow at char index 284'
+      text: '285 chars- http://www.twitter.com/jack xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-'
+      expected:
+        weightedLength: 299
+        valid: false
+        permillage: 1067
+        displayRangeStart: 0
+        displayRangeEnd: 302
+        validRangeStart: 0
+        validRangeEnd: 283
+
+    - description: 'Long tweet with url at the end, overflow at char index 265'
+      text: 'xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx- http://www.twitter.com/jack '
+      expected:
+        weightedLength: 289
+        valid: false
+        permillage: 1032
+        displayRangeStart: 0
+        displayRangeEnd: 292
+        validRangeStart: 0
+        validRangeEnd: 264
+
+    - description: '10 url string, no overflow'
+      text: 'https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha https://www.twitter.com/aloha '
+      expected:
+        weightedLength: 240
+        valid: true
+        permillage: 857
+        displayRangeStart: 0
+        displayRangeEnd: 299
+        validRangeStart: 0
+        validRangeEnd: 299
+
+    - description: '160 CJK char, overflow at char index 140'
+      text: '故人西辞黄鹤楼，烟花三月下扬州。孤帆远影碧空尽，唯见长江天际流。朱雀桥边野草花，乌衣巷口夕阳斜。旧时王谢堂前燕，飞入寻常百姓家。朝辞白帝彩云间，千里江陵一日还。两岸猿声啼不住，轻舟已过万重山。泪湿罗巾梦不成，夜深前殿按歌声。红颜未老恩先断，斜倚薰笼坐到明。独在异乡为异客，每逢佳节倍思亲。遥知兄弟登高处，遍插茱萸少一人。'
+      expected:
+        weightedLength: 320
+        valid: false
+        permillage: 1142
+        displayRangeStart: 0
+        displayRangeEnd: 159
+        validRangeStart: 0
+        validRangeEnd: 139
+
+    - description: '160 emoji char, overflow at char index 140'
+      text: '😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷😷'
+      expected:
+        weightedLength: 320
+        valid: false
+        permillage: 1142
+        displayRangeStart: 0
+        displayRangeEnd: 319
+        validRangeStart: 0
+        validRangeEnd: 279
+
+    - description: '3 latin char + 160 CJK char, overflow at char index 141'
+      text: 'the故人西辞黄鹤楼，烟花三月下扬州。孤帆远影碧空尽，唯见长江天际流。朱雀桥边野草花，乌衣巷口夕阳斜。旧时王谢堂前燕，飞入寻常百姓家。朝辞白帝彩云间，千里江陵一日还。两岸猿声啼不住，轻舟已过万重山。泪湿罗巾梦不成，夜深前殿按歌声。红颜未老恩先断，斜倚薰笼坐到明。独在异乡为异客，每逢佳节倍思亲。遥知兄弟登高处，遍插茱萸少一人。'
+      expected:
+        weightedLength: 323
+        valid: false
+        permillage: 1153
+        displayRangeStart: 0
+        displayRangeEnd: 162
+        validRangeStart: 0
+        validRangeEnd: 140
+
+    - description: '282 chars with a normalized character within valid range but outside 280'
+      text: '282 chars-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxÁx'
+      expected:
+        weightedLength: 281
+        valid: false
+        permillage: 1003
+        displayRangeStart: 0
+        displayRangeEnd: 281
+        validRangeStart: 0
+        validRangeEnd: 280
+
+    - description: 'Count a mix of single byte single word, and double word unicode characters'
+      text: 'H🐱☺👨‍👩‍👧‍👦'
+      expected:
+        weightedLength: 7
+        valid: true
+        permillage: 25
+        displayRangeStart: 0
+        displayRangeEnd: 14
+        validRangeStart: 0
+        validRangeEnd: 14
+
+    - description: 'Count unicode emoji chars inside the basic multilingual plane'
+      text: '😷👾😡🔥💩'
+      expected:
+        weightedLength: 10
+        valid: true
+        permillage: 35
+        displayRangeStart: 0
+        displayRangeEnd: 9
+        validRangeStart: 0
+        validRangeEnd: 9
+
+    - description: 'Count unicode emoji chars outside the basic multilingual plane with skin tone modifiers'
+      text: '🙋🏽👨‍🎤'
+      expected:
+        weightedLength: 4
+        valid: true
+        permillage: 14
+        displayRangeStart: 0
+        displayRangeEnd: 8
+        validRangeStart: 0
+        validRangeEnd: 8
+
+    - description: 'Handle General Punctuation Characters with visible spaces(u2000-200A), no ZWJ/ZWNJ'
+      text: "This is a tweet with general punctuation characters: \u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u200B ‐ ‑ ‒ – — ― ‖  ‗ ‘ ’ ‚ ‛ “ ” „ ‟ ′ ″ ‴ ‵ ‶ ‷"
+      expected:
+        weightedLength: 110
+        valid: true
+        permillage: 392
+        displayRangeStart: 0
+        displayRangeEnd: 109
+        validRangeStart: 0
+        validRangeEnd: 109
+
+    - description: 'Handle long url with invalid domain labels and short url'
+      text: 'Long url with invalid domain labels and a short url: https://somesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurl.com/foo https://somesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurl.com/foo https://somesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurlsomesuperlongurl.com/foo https://validurl.com'
+      expected:
+        weightedLength: 12079
+        valid: false
+        permillage: 43139
+        displayRangeStart: 0
+        displayRangeEnd: 12075
+        validRangeStart: 0
+        validRangeEnd: 279
+
+    - description: 'Handle a 64 character domain without protocol'
+      text: 'randomurlrandomurlrandomurlrandomurlrandomurlrandomurlrandomurls.com'
+      expected:
+        weightedLength: 68
+        valid: true
+        permillage: 242
+        displayRangeStart: 0
+        displayRangeEnd: 67
+        validRangeStart: 0
+        validRangeEnd: 67
+
+    - description: 'Do not allow > 140 CJK characters by virtue of CJK chars greater than 63 punycode encoded chars in the host'
+      text: 'あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこ http://あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいう.com'
+      expected:
+        weightedLength: 358
+        valid: false
+        permillage: 1278
+        displayRangeStart: 0
+        displayRangeEnd: 184
+        validRangeStart: 0
+        validRangeEnd: 143
+
+    - description: 'Allow > 140 CJK characters by virtue of CJK chars less than 63 punycode encoded chars in the host'
+      text: 'あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこ http://あいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあいうえおかきくけこあい.com'
+      expected:
+        weightedLength: 264
+        valid: true
+        permillage: 942
+        displayRangeStart: 0
+        displayRangeEnd: 183
+        validRangeStart: 0
+        validRangeEnd: 183
+
+    - description: '140 family emoji'
+      text: '👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦'
+      expected:
+        weightedLength: 280
+        valid: true
+        permillage: 1000
+        displayRangeStart: 0
+        displayRangeEnd: 1539
+        validRangeStart: 0
+        validRangeEnd: 1539
+
+    - description: 'Emoji with a leading character in the latin range is counted as 2'
+      text: '1⃣'
+      expected:
+        weightedLength: 2
+        valid: true
+        permillage: 7
+        displayRangeStart: 0
+        displayRangeEnd: 1
+        validRangeStart: 0
+        validRangeEnd: 1
+
+    - description: 'Unicode 10.0 emoji'
+      text: 'Unicode 10.0 emoji: 🤪; 🧕; 🧕🏾; 🏴󠁧󠁢󠁥󠁮󠁧󠁿'
+      expected:
+        weightedLength: 34
+        valid: true
+        permillage: 121
+        displayRangeStart: 0
+        displayRangeEnd: 47
+        validRangeStart: 0
+        validRangeEnd: 47
+
+    - description: 'Unicode 9.0 emoji'
+      text: 'Unicode 9.0 emoji: 🤠; 💃; 💃🏾'
+      expected:
+        weightedLength: 29
+        valid: true
+        permillage: 103
+        displayRangeStart: 0
+        displayRangeEnd: 30
+        validRangeStart: 0
+        validRangeEnd: 30
+
+  UnicodeDirectionalMarkerCounterTest:
+    - description: 'Handle invalid characters'
+      text: "ABC\u202A\uFFFFABC\uFFFE"
+      expected:
+        weightedLength: 12
+        valid: false
+        permillage: 42
+        displayRangeStart: 0
+        displayRangeEnd: 8
+        validRangeStart: 0
+        validRangeEnd: 3
+
+    - description: 'Tweet text containing directional characters should be considered valid'
+      text: "\U00002066\U0000202Ahttp://foobar.پاکستان/\U0000202C\U00002069"
+      expected:
+        weightedLength: 31
+        valid: true
+        permillage: 110
+        displayRangeStart: 0
+        displayRangeEnd: 25
+        validRangeStart: 0
+        validRangeEnd: 25

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -234,8 +234,13 @@ func ExtractUrls(text string) []*TwitterEntity {
 			// Make sure the protocol-less domain is ascii only
 			// e.g., in the case of "한국twitter.com", only extract twitter.com
 			if m := validAsciiDomain.FindStringSubmatchIndex(substr[domainStart:domainEnd]); m != nil {
+
+				text := substr[matchStart+m[0] : matchStart+m[1]]
+				if !areDomainLengthsValid(text) {
+					continue
+				}
 				lastEntity = &TwitterEntity{
-					Text: substr[matchStart+m[0] : matchStart+m[1]],
+					Text: text,
 					ByteRange: Range{
 						Start: matchStart + offset + m[0],
 						Stop:  matchStart + offset + m[1]},
@@ -278,6 +283,9 @@ func ExtractUrls(text string) []*TwitterEntity {
 				url = url[tcoLoc[0]:tcoLoc[1]]
 				matchEnd = matchStart + len(url)
 			}
+			if !areDomainLengthsValid(url) {
+				continue
+			}
 			result = append(result,
 				&TwitterEntity{Text: url,
 					ByteRange: Range{
@@ -290,6 +298,17 @@ func ExtractUrls(text string) []*TwitterEntity {
 	// Add character/rune offsets in addition to byte offsets
 	result.fixIndices(text)
 	return result
+}
+
+func areDomainLengthsValid(domain string) bool {
+	domainLabels := strings.Split(domain, ".")
+	const MAX_DOMAIN_LABEL_LENGTH = 63
+	for _, label := range domainLabels {
+		if len(label) > MAX_DOMAIN_LABEL_LENGTH {
+			return false
+		}
+	}
+	return true
 }
 
 // Extracts @username mentions from the supplied text. Returns a slice

--- a/extract/extract.go
+++ b/extract/extract.go
@@ -250,9 +250,7 @@ func ExtractUrls(text string) []*TwitterEntity {
 				nextOffset = matchStart + m[1] + offset - 1
 
 				// If the url has a Generic TLD (not CC TLD), it's valid
-				if lastInvalid = invalidShortDomain.MatchString(lastEntity.Text); !lastInvalid {
-					result = append(result, lastEntity)
-				}
+				result = append(result, lastEntity)
 			}
 
 			if lastEntity == nil {

--- a/extract/extract_url_test.go
+++ b/extract/extract_url_test.go
@@ -39,7 +39,7 @@ func TestExtractUrls(t *testing.T) {
 		}
 
 		if len(result) != len(expected) {
-			t.Errorf("Wrong number of entities returned for text [%s]. Expected:%v Got:%v.\n", test.Text, expected, result)
+			t.Errorf("Wrong number of entities returned for text [%s]. Expected:%v Got:%v.\n", test.Description, expected, result)
 			continue
 		}
 
@@ -47,7 +47,7 @@ func TestExtractUrls(t *testing.T) {
 			actual := result[n]
 			tmpValue := e.(string)
 			if actual.Text != tmpValue {
-				t.Errorf("ExtractUrls returned incorrect value for test: [%s]. Expected:[%s] Got:[%s]\n", test.Text, tmpValue, actual.Text)
+				t.Errorf("ExtractUrls returned incorrect value for test: [%s]. Expected:[%s] Got:[%s]\n", test.Description, tmpValue, actual.Text)
 			}
 
 			if actual.Type != URL {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/kylemcc/twitter-text-go
+
+go 1.16
+
+require (
+	golang.org/x/text v0.3.6
+	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0 h1:POO/ycCATvegFmVuPpQzZFJ+pGZeX22Ufu6fibxDVjU=
+gopkg.in/yaml.v1 v1.0.0-20140924161607-9f9df34309c0/go.mod h1:WDnlLJ4WF5VGsH/HVa3CI79GS0ol3YnhVnKP89i0kNg=

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	maxLength           = 140
+	maxLength           = 280
 	shortUrlLength      = 23
 	shortHttpsUrlLength = 23
 	invalidChars        = "\uFFFE\uFEFF\uFFFF\u202A\u202B\u202C\u202D\u202E"

--- a/validate/validate_length_test.go
+++ b/validate/validate_length_test.go
@@ -26,7 +26,7 @@ func TestTweetLength(t *testing.T) {
 		t.FailNow()
 	}
 
-	lengthTests, ok := tests.(map[interface{}]interface{})["lengths"]
+	lengthTests, ok := tests.(map[interface{}]interface{})["WeightedTweetsCounterTest"]
 	if !ok {
 		t.Errorf("Conformance file did not contain length tests")
 		t.FailNow()
@@ -34,12 +34,13 @@ func TestTweetLength(t *testing.T) {
 
 	for _, testCase := range lengthTests.([]interface{}) {
 		test := testCase.(map[interface{}]interface{})
-		text, _ := test["text"]
-		description, _ := test["description"]
-		expected, _ := test["expected"]
+		text := test["text"]
+		description := test["description"]
+		expected := test["expected"]
+		length := expected.(map[interface{}]interface{})["weightedLength"]
 
 		actual := TweetLength(text.(string))
-		if actual != expected {
+		if actual != length {
 			t.Errorf("TweetLength returned incorrect value for test [%s]. Expected:%v Got:%v", description, expected, actual)
 		}
 	}

--- a/validate/validate_length_test.go
+++ b/validate/validate_length_test.go
@@ -39,9 +39,9 @@ func TestTweetLength(t *testing.T) {
 		expected := test["expected"]
 		length := expected.(map[interface{}]interface{})["weightedLength"]
 
-		actual := TweetLength(text.(string))
-		if actual != length {
-			t.Errorf("TweetLength returned incorrect value for test [%s]. Expected:%v Got:%v", description, expected, actual)
+		actual, _ := ParseTweet(text.(string))
+		if actual.WeightedLength != length {
+			t.Errorf("TweetWeightedLength returned incorrect value for test [%s]. Expected:%v Got:%v", description, length, actual.WeightedLength)
 		}
 	}
 }


### PR DESCRIPTION
Solves https://github.com/kylemcc/twitter-text-go/issues/6

I was curious to see what work it would take to pass the latest conformance.yml for validating the tweet length. It's actually not too bad. The main thing missing is an edge case around the URL domain length. Cyrillic domains aren't handled properly, but that's an existing issue.


The main problem/API decision is what to do about the length. Twitter decided to keep `getTweetLength` around as a deprecated API, and implemented `parseTweet` instead with the weighted length. In twitter's world, getTweetLength is limited to 140 characters, but parseTweet is now up to 280.

Just to make the tests pass (since they do check both), I made a new `ParseTweet` function but I'm open for suggestions to how this should work.


Acceptance criteria:
Most of the validation package tests work. The two failing ones are unimplemented functionality
validate_url_test.go:43: UrlIsValid returned incorrect value for test [Valid url: Cyrillic characters in path]. Expected:true Got:false
validate_length_test.go:44: TweetWeightedLength returned incorrect value for test [Allow > 140 CJK characters by virtue of CJK chars less than 63 punycode encoded chars in the host]. Expected:264 Got:356